### PR TITLE
:construction: (feature/login) 카카오 로그인을 위한 사전 설정 완료

### DIFF
--- a/ItsME/Application/AppDelegate.swift
+++ b/ItsME/Application/AppDelegate.swift
@@ -6,6 +6,7 @@
 //
 
 import UIKit
+import RxKakaoSDKCommon
 
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
@@ -13,7 +14,13 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-        // Override point for customization after application launch.
+        
+        let infoDictionaryKey: String = "KAKAO_NATIVE_APP_KEY"
+        guard let appKey = Bundle.main.object(forInfoDictionaryKey: infoDictionaryKey) as? String else {
+            fatalError("Info.plist 파일에 \(infoDictionaryKey) 키 항목이 없습니다.")
+        }
+        RxKakaoSDK.initSDK(appKey: appKey)
+        
         return true
     }
 

--- a/ItsME/Application/SceneDelegate.swift
+++ b/ItsME/Application/SceneDelegate.swift
@@ -6,6 +6,8 @@
 //
 
 import UIKit
+import KakaoSDKAuth
+import RxKakaoSDKAuth
 
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
@@ -21,6 +23,14 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         window?.makeKeyAndVisible()
     }
 
+    func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {
+        if let url = URLContexts.first?.url {
+            if (AuthApi.isKakaoTalkLoginUrl(url)) {
+                _ = AuthController.rx.handleOpenUrl(url: url)
+            }
+        }
+    }
+    
     func sceneDidDisconnect(_ scene: UIScene) {
         // Called as the scene is being released by the system.
         // This occurs shortly after the scene enters the background, or when its session is discarded.

--- a/ItsME/Resources/Info.plist
+++ b/ItsME/Resources/Info.plist
@@ -2,6 +2,24 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>KAKAO_NATIVE_APP_KEY</key>
+	<string>ff28d124ec4c8b9e53c3bc5697ec592f</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>kakaoff28d124ec4c8b9e53c3bc5697ec592f</string>
+			</array>
+		</dict>
+	</array>
+	<key>LSApplicationQueriesSchemes</key>
+	<array>
+		<string>kakaokompassauth</string>
+		<string>kakaolink</string>
+	</array>
 	<key>Localization native development region</key>
 	<string>Korea</string>
 	<key>UIApplicationSceneManifest</key>


### PR DESCRIPTION
## 부가 설명
<!-- 필요 시 작성 -->
- KakaoSDK 초기화 수행
- 카카오 앱에서 돌아왔을때 실행할 완료 핸들러 추가
- URL Scheme 설정


## 참고 자료 & 토론
<!-- 필요 시 작성 -->
<!-- 이미지, 링크, 플로우차트 등등 -->
### Native app key 숨김?
- [github에 올리면 안되는 APIKEY 숨기기 - iOS](https://nareunhagae.tistory.com/44)
- [[iOS] github에 API Key 숨기기](https://velog.io/@leedool3003/iOS-API-Key-%EC%88%A8%EA%B8%B0%EA%B8%B0)
- [[Swift] Plist를 활용해서 API key(민감정보) 가리기 (plist, 연산 프로퍼티, .gitignore)](https://velog.io/@loopbackseal/Swift-Plist%EB%A5%BC-%ED%99%9C%EC%9A%A9%ED%95%B4%EC%84%9C-API-key%EB%AF%BC%EA%B0%90%EC%A0%95%EB%B3%B4-%EA%B0%80%EB%A6%AC%EA%B8%B0)
- [Bundle Structures](https://developer.apple.com/library/archive/documentation/CoreFoundation/Conceptual/CFBundles/BundleTypes/BundleTypes.html#//apple_ref/doc/uid/10000123i-CH101-SW1)
- [애플리케이션의 민감한 정보를 보호하는 방법](https://nshipster.co.kr/secrets/)

github 에 Native App Key 를 포함한 민감한 정보를 올리고 싶지 않을때 어떤 방법을 쓰면 좋을까 하고 찾아본 자료입니다.  
위의 정보들을 종합해서 판단한 그나마 좋은 방법은 Info.plist 파일을 .gitignore 에 추가하는 것입니다. 
   
- 지금은 .gitignore 에 추가하지 않은 상태인데 이를 추가하는거에 대해서 어떻게 생각하나요?  
- 다른 좋은 방법을 추천해주거나, 왜 Info.plist 파일을 .gitignore 에 추가하는게 가장 좋은 방법이라고 생각했는지 궁금한거에 대해 자유롭게 코멘트를 달아주세용


## PR Checklist
<!-- 만족하는 항목은 [ ] 안에 "x" 를 입력해주세요. (ex: [x]) -->
<!-- 꼭!!! 체크하기 전에 다시 한번 확인해주세요!! -->

- [ ] 변경 사항을 적용하고 빌드&테스트 실행을 해봤나요?
<!-- - [ ] [Code Convention](https://il-gob.notion.site/Code-Convention-29ce0d4e48e440b9bc74b1a19c99b57b)을 준수했나요? -->
