### PR TITLE
애플 로그인 구현

### DIFF
--- a/ItsME.xcodeproj/project.pbxproj
+++ b/ItsME.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		DA0A88692921245000E9AE43 /* UserRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA0A88682921245000E9AE43 /* UserRepository.swift */; };
 		DA6BCE5E292F04910059E95D /* DatabaseReferenceManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA6BCE5D292F04910059E95D /* DatabaseReferenceManager.swift */; };
 		DA7201E7292F6A0600A69519 /* DatabaseReference+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA7201E6292F6A0600A69519 /* DatabaseReference+Rx.swift */; };
+		DA7201EA29309B2F00A69519 /* ASAuthorizationControllerDelegateProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA7201E929309B2F00A69519 /* ASAuthorizationControllerDelegateProxy.swift */; };
 		DA739DDA292398BE003AEE4C /* LoginViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA739DD9292398BE003AEE4C /* LoginViewController.swift */; };
 		DA739DDC292398C3003AEE4C /* LoginViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA739DDB292398C3003AEE4C /* LoginViewModel.swift */; };
 		DA739DE42924FE54003AEE4C /* CommonAlertViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA739DE32924FE54003AEE4C /* CommonAlertViewController.swift */; };
@@ -80,6 +81,7 @@
 		DA0A88682921245000E9AE43 /* UserRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserRepository.swift; sourceTree = "<group>"; };
 		DA6BCE5D292F04910059E95D /* DatabaseReferenceManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatabaseReferenceManager.swift; sourceTree = "<group>"; };
 		DA7201E6292F6A0600A69519 /* DatabaseReference+Rx.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DatabaseReference+Rx.swift"; sourceTree = "<group>"; };
+		DA7201E929309B2F00A69519 /* ASAuthorizationControllerDelegateProxy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ASAuthorizationControllerDelegateProxy.swift; sourceTree = "<group>"; };
 		DA739DD9292398BE003AEE4C /* LoginViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginViewController.swift; sourceTree = "<group>"; };
 		DA739DDB292398C3003AEE4C /* LoginViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginViewModel.swift; sourceTree = "<group>"; };
 		DA739DDD2923B4D2003AEE4C /* ItsME.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = ItsME.entitlements; sourceTree = "<group>"; };
@@ -307,6 +309,7 @@
 				DA7201E5292F684900A69519 /* Extensions */,
 				DAB06A41291BA8C800E86163 /* Protocols */,
 				D0CCF4E02925FB0100AD4AE6 /* UIView+.swift */,
+				DA7201E929309B2F00A69519 /* ASAuthorizationControllerDelegateProxy.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -566,6 +569,7 @@
 				DA0A88692921245000E9AE43 /* UserRepository.swift in Sources */,
 				D0CCF4E12925FB0100AD4AE6 /* UIView+.swift in Sources */,
 				D0CCF4E629260C2B00AD4AE6 /* ProfileInfoComponent.swift in Sources */,
+				DA7201EA29309B2F00A69519 /* ASAuthorizationControllerDelegateProxy.swift in Sources */,
 				DA739DDA292398BE003AEE4C /* LoginViewController.swift in Sources */,
 				D09AC9752918DE8B0081C0EC /* AppDelegate.swift in Sources */,
 				DA739DE42924FE54003AEE4C /* CommonAlertViewController.swift in Sources */,

--- a/ItsME.xcodeproj/project.pbxproj
+++ b/ItsME.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		DA6BCE5E292F04910059E95D /* DatabaseReferenceManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA6BCE5D292F04910059E95D /* DatabaseReferenceManager.swift */; };
 		DA7201E7292F6A0600A69519 /* DatabaseReference+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA7201E6292F6A0600A69519 /* DatabaseReference+Rx.swift */; };
 		DA7201EA29309B2F00A69519 /* ASAuthorizationControllerDelegateProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA7201E929309B2F00A69519 /* ASAuthorizationControllerDelegateProxy.swift */; };
+		DA7201EC29309B9600A69519 /* AuthenticationServices+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA7201EB29309B9600A69519 /* AuthenticationServices+Rx.swift */; };
 		DA739DDA292398BE003AEE4C /* LoginViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA739DD9292398BE003AEE4C /* LoginViewController.swift */; };
 		DA739DDC292398C3003AEE4C /* LoginViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA739DDB292398C3003AEE4C /* LoginViewModel.swift */; };
 		DA739DE42924FE54003AEE4C /* CommonAlertViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA739DE32924FE54003AEE4C /* CommonAlertViewController.swift */; };
@@ -82,6 +83,7 @@
 		DA6BCE5D292F04910059E95D /* DatabaseReferenceManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatabaseReferenceManager.swift; sourceTree = "<group>"; };
 		DA7201E6292F6A0600A69519 /* DatabaseReference+Rx.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DatabaseReference+Rx.swift"; sourceTree = "<group>"; };
 		DA7201E929309B2F00A69519 /* ASAuthorizationControllerDelegateProxy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ASAuthorizationControllerDelegateProxy.swift; sourceTree = "<group>"; };
+		DA7201EB29309B9600A69519 /* AuthenticationServices+Rx.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AuthenticationServices+Rx.swift"; sourceTree = "<group>"; };
 		DA739DD9292398BE003AEE4C /* LoginViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginViewController.swift; sourceTree = "<group>"; };
 		DA739DDB292398C3003AEE4C /* LoginViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginViewModel.swift; sourceTree = "<group>"; };
 		DA739DDD2923B4D2003AEE4C /* ItsME.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = ItsME.entitlements; sourceTree = "<group>"; };
@@ -227,6 +229,7 @@
 			isa = PBXGroup;
 			children = (
 				DA7201E6292F6A0600A69519 /* DatabaseReference+Rx.swift */,
+				DA7201EB29309B9600A69519 /* AuthenticationServices+Rx.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -564,6 +567,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				DAAFB2532918EE5A007A8DF0 /* UserInfo.swift in Sources */,
+				DA7201EC29309B9600A69519 /* AuthenticationServices+Rx.swift in Sources */,
 				D09AC9792918DE8B0081C0EC /* HomeViewController.swift in Sources */,
 				DAB06A40291BA61100E86163 /* ViewModelType.swift in Sources */,
 				DA0A88692921245000E9AE43 /* UserRepository.swift in Sources */,

--- a/ItsME/Presentation/Scenes/Login/LoginViewController.swift
+++ b/ItsME/Presentation/Scenes/Login/LoginViewController.swift
@@ -48,7 +48,9 @@ private extension LoginViewController {
     func bindViewModel() {
         let input = LoginViewModel.Input.init(
             kakaoLoginRequest: kakaoLoginButton.rx.tap.asSignal(),
-            appleLoginRequest: appleLoginButton.rx.controlEvent(.touchUpInside).asSignal()
+            appleLoginSuccess: appleLoginButton.rx
+                .tapToLogin(scope: [.fullName, .email])
+                .asDriver(onErrorDriveWith: .empty())
         )
         let output = viewModel.transform(input: input)
         

--- a/ItsME/Presentation/Scenes/Login/LoginViewModel.swift
+++ b/ItsME/Presentation/Scenes/Login/LoginViewModel.swift
@@ -5,6 +5,7 @@
 //  Created by Jaewon Yun on 2022/11/15.
 //
 
+import AuthenticationServices
 import RxSwift
 import RxCocoa
 import KakaoSDKUser
@@ -14,7 +15,7 @@ final class LoginViewModel: ViewModelType {
     
     struct Input {
         let kakaoLoginRequest: Signal<Void>
-        let appleLoginRequest: Signal<Void>
+        let appleLoginSuccess: Driver<ASAuthorization>
     }
     
     struct Output {
@@ -28,8 +29,21 @@ final class LoginViewModel: ViewModelType {
                     .asDriver(onErrorDriveWith: .empty())
             }
         
-        let loggedInApple = input.appleLoginRequest
-            .asDriver(onErrorDriveWith: .empty())
+        let loggedInApple = input.appleLoginSuccess
+            .do(onNext: { authorization in
+                // TODO: Firebase 계정 생성
+                #if DEBUG
+                    guard let appleIDCredential = authorization.credential as? ASAuthorizationAppleIDCredential else {
+                        return
+                    }
+                    print("authorizationCode : \(String(data: appleIDCredential.authorizationCode!, encoding: .utf8))")
+                    print("identityToken : \(String(data: appleIDCredential.identityToken!, encoding: .utf8))")
+                    print("uid : \(appleIDCredential.user)")
+                    print("name : \(appleIDCredential.fullName)")
+                    print("email : \(appleIDCredential.email)")
+                #endif
+            })
+            .map { _ -> Void in }
         
         let loggedIn = Driver.merge(loggedInKakao, loggedInApple)
         

--- a/ItsME/Utils/ASAuthorizationControllerDelegateProxy.swift
+++ b/ItsME/Utils/ASAuthorizationControllerDelegateProxy.swift
@@ -1,0 +1,50 @@
+//
+//  ASAuthorizationControllerDelegateProxy.swift
+//  ItsME
+//
+//  Created by Jaewon Yun on 2022/11/25.
+//
+
+import AuthenticationServices
+import RxSwift
+import RxCocoa
+import UIKit
+
+@available(iOS 13.0, *)
+class ASAuthorizationControllerDelegateProxy:
+    DelegateProxy<ASAuthorizationController, ASAuthorizationControllerDelegate>,
+    DelegateProxyType
+{
+    static func registerKnownImplementations() {
+        self.register { authrizationController in
+            ASAuthorizationControllerDelegateProxy.init(
+                parentObject: authrizationController,
+                delegateProxy: ASAuthorizationControllerDelegateProxy.self
+            )
+        }
+    }
+    
+    static func currentDelegate(for object: ASAuthorizationController) -> ASAuthorizationControllerDelegate? {
+        object.delegate
+    }
+    
+    static func setCurrentDelegate(_ delegate: ASAuthorizationControllerDelegate?, to object: ASAuthorizationController) {
+        object.delegate = delegate
+    }
+}
+
+@available(iOS 13.0, *)
+extension ASAuthorizationControllerDelegateProxy:
+    ASAuthorizationControllerDelegate,
+    ASAuthorizationControllerPresentationContextProviding
+{
+    func authorizationController(controller: ASAuthorizationController, didCompleteWithError error: Error) {
+        #if DEBUG
+            print(error.localizedDescription)
+        #endif
+    }
+    
+    func presentationAnchor(for controller: ASAuthorizationController) -> ASPresentationAnchor {
+        return UIWindow.init()
+    }
+}

--- a/ItsME/Utils/Extensions/AuthenticationServices+Rx.swift
+++ b/ItsME/Utils/Extensions/AuthenticationServices+Rx.swift
@@ -1,0 +1,54 @@
+//
+//  AuthenticationServices+Rx.swift
+//  ItsME
+//
+//  Created by Jaewon Yun on 2022/11/25.
+//
+
+import AuthenticationServices
+import RxSwift
+import RxCocoa
+import UIKit
+
+// MARK: - ASAuthorizationController+Rx
+
+@available(iOS 13.0, *)
+extension Reactive where Base: ASAuthorizationController {
+    
+    var delegateProxy: DelegateProxy<ASAuthorizationController, ASAuthorizationControllerDelegate> {
+        return ASAuthorizationControllerDelegateProxy.proxy(for: self.base)
+    }
+    
+    var didCompleteWithAuthorization: Observable<ASAuthorization> {
+        let selector = #selector(ASAuthorizationControllerDelegate.authorizationController(controller:didCompleteWithAuthorization:))
+        return delegateProxy
+            .methodInvoked(selector)
+            .map { parameters in
+                guard let authorization = parameters[1] as? ASAuthorization else {
+                    fatalError("authorizationController(controller:didCompleteWithAuthorization:) 함수의 두번째 파라미터가 ASAuthorization 타입이 아닙니다.")
+                }
+                return authorization
+            }
+    }
+}
+
+// MARK: - ASAuthorizationAppleIDButton+Rx
+
+@available(iOS 13.0, *)
+extension Reactive where Base: ASAuthorizationAppleIDButton {
+    
+    func tapToLogin(scope: [ASAuthorization.Scope]? = nil) -> Observable<ASAuthorization> {
+        return controlEvent(.touchUpInside)
+            .flatMap {
+                let appleIDProvider = ASAuthorizationAppleIDProvider.init()
+                
+                let request = appleIDProvider.createRequest()
+                request.requestedScopes = scope
+                
+                let authorizationController = ASAuthorizationController.init(authorizationRequests: [request])
+                authorizationController.performRequests()
+                
+                return authorizationController.rx.didCompleteWithAuthorization
+            }
+    }
+}


### PR DESCRIPTION
## 변경점 설명
<!-- 필요 시 작성 -->
- HomeViewModel 에 애플 로그인 요청을 바인딩하던 로직에서 애플 로그인 결과를 바인딩하도록 변경
  - 애플 로그인 진행 플로우는 ViewController 에서 진행
  - Firebase 계정 생성은 ViewModel 에게 위임
- 애플 로그인을 구현하려면 해당 ViewController 에서 Delegate 를 구현해줘야하지만, Rx 를 적용하여 ViewController 의 일관성을 유지하기 위해 DelegateProxy 와 Reactive extension 사용
  - 처음 구현해보는 방식이라 추후에 생각지 못한 이슈가 발생할 수 있지만 현재는 잘 동작한다...
  - 
## About Sign In with Apple
#### Login/Logout
앱에서 처음 로그인 할때만 이메일과, 이름 정보를 받을 수 있고 2번째 로그인부터는 해당 정보를 받을 수 없음
-> 사용자가 앱에 처음 로그인할 때 받은 이메일, 이름 정보로 회원가입 처리, 고정된 user identifier 값으로 계정 생성
-> 이후에 사용자 로그아웃, 로그인 시 고정된 user identifier 값으로 유저 구별
#### 회원 탈퇴
- 사용자가 회원 탈퇴 요청 시 Apple Server 에 API 요청을 통해 사용자 토큰을 삭제해야 된다고 함
  - 아마 사용자 토큰 삭제 시, 로그인 했을때 다시 이메일, 이름 정보를 받을 수 있는듯?
  - 참고 포스트
    - https://velog.io/@givepro91/jjo2cyus
    - https://hwannny.tistory.com/71#recentEntries

근데 이게 간단하지가 않다.... Firebase 를 통해 쉽게 해결할 수 있는지는 계정 생성 등을 더 진행해봐야 알것같다.



## 참고 자료
<!-- 필요 시 작성 -->
<!-- 이미지, 링크, 플로우차트 등등 -->
#### DelegateProxy
- https://brunch.co.kr/@tilltue/24
- https://velog.io/@yujinj/RxSwift-DelegateProxy
- https://ios-development.tistory.com/152
- https://eunjin3786.tistory.com/28
- https://gist.github.com/iamchiwon/20aa57d4e8f6110bc3f79742c2fb6cc5 (Apple Login 에 Rx 적용한 코드)



## PR Checklist
<!-- 만족하는 항목은 [ ] 안에 "x" 를 입력해주세요. (ex: [x]) -->
<!-- 꼭!!! 체크하기 전에 다시 한번 확인해주세요!! -->

- [x] 변경 사항을 적용하고 빌드&테스트 실행을 해봤나요?
<!-- - [ ] [Code Convention](https://il-gob.notion.site/Code-Convention-29ce0d4e48e440b9bc74b1a19c99b57b)을 준수했나요? -->
