### PR TITLE
HomeViewModel 구현

### DIFF
--- a/ItsME/Presentation/Scenes/Home/HomeViewController.swift
+++ b/ItsME/Presentation/Scenes/Home/HomeViewController.swift
@@ -54,19 +54,45 @@ private extension HomeViewController {
     }
     
     func bindViewModel() {
+        let input = makeInput()
+        let output = viewModel.transform(input: input)
+        
+        output.userInfo
+            .drive(userInfoBinding)
+            .disposed(by: disposeBag)
+        
+        output.cvsInfo
+            .drive(cvsInfoBinding)
+            .disposed(by: disposeBag)
+    }
+    
+    func makeInput() -> HomeViewModel.Input {
+        let viewDidLoad = Observable.just(())
+            .map { _ in }
+            .asSignal(onErrorSignalWith: .empty())
+        
         let viewWillAppear = self.rx.sentMessage(#selector(self.viewWillAppear(_:)))
             .map { _ in }
             .asSignal(onErrorSignalWith: .empty())
         
-        let input = HomeViewModel.Input(viewWillAppear: viewWillAppear)
-        let output = viewModel.transform(input: input)
-        
-        output.userInfo
-            .drive(onNext: { userInfo in
-                // input 에 대한 output 으로 userInfo 를 받았을 때 수행할 작업 정의
-                print(userInfo)
-            })
-            .disposed(by: disposeBag)
+        return .init(
+            viewDidLoad: viewDidLoad,
+            viewWillAppear: viewWillAppear
+        )
+    }
+    
+    var userInfoBinding: Binder<UserInfo> {
+        return .init(self) { viewController, userInfo in
+            // UserInfo 가 필요한 곳에 데이터 매핑
+            print(userInfo.name)
+        }
+    }
+    
+    var cvsInfoBinding: Binder<[CVInfo]> {
+        return .init(self) { viewController, cvsInfo in
+            // CVsInfo 가 필요한 곳에 데이터 매핑
+            print(cvsInfo.count)
+        }
     }
     
     func configureSubviews() {

--- a/ItsME/Presentation/Scenes/Home/HomeViewController.swift
+++ b/ItsME/Presentation/Scenes/Home/HomeViewController.swift
@@ -45,13 +45,9 @@ final class HomeViewController: UIViewController {
     }
 }
 
-// MARK: - Private functions
+// MARK: - Binding ViewModel
 
 private extension HomeViewController {
-    
-    func configureAppearance() {
-        self.view.backgroundColor = .white
-    }
     
     func bindViewModel() {
         let input = makeInput()
@@ -93,6 +89,15 @@ private extension HomeViewController {
             // CVsInfo 가 필요한 곳에 데이터 매핑
             print(cvsInfo.count)
         }
+    }
+}
+
+// MARK: - Private functions
+
+private extension HomeViewController {
+    
+    func configureAppearance() {
+        self.view.backgroundColor = .white
     }
     
     func configureSubviews() {


### PR DESCRIPTION
# #33 

## 변경점 설명
<!-- 필요 시 작성 -->
- ViewModel 에 CV 데이터 가져오는 로직 추가
- 조금 미리 데이터를 가져올 수 있도록 viewDidLoad 함수 바인딩
- ViewModel 에 대한 Input 을 생성하는 부분 팩토리 메소드로 분리
- 코드 가독성을 위해 MARK 로 코드 분리

## Binder
`userInfoBinding`, `cvsInfoBinding` 프로퍼티로 데이터를 매핑하면 됩니다.

## PR Checklist
<!-- 만족하는 항목은 [ ] 안에 "x" 를 입력해주세요. (ex: [x]) -->
<!-- 꼭!!! 체크하기 전에 다시 한번 확인해주세요!! -->

- [x] 변경 사항을 적용하고 빌드&테스트 실행을 해봤나요?
<!-- - [ ] [Code Convention](https://il-gob.notion.site/Code-Convention-29ce0d4e48e440b9bc74b1a19c99b57b)을 준수했나요? -->
