### PR TITLE
:construction: (feature/HomeView) HomeView에 UserInfoItem 데이터 바인딩 처리 #40

### DIFF
--- a/ItsME/Presentation/Scenes/Home/HomeViewController.swift
+++ b/ItsME/Presentation/Scenes/Home/HomeViewController.swift
@@ -129,8 +129,7 @@ private extension HomeViewController {
     
     var userInfoBinding: Binder<UserInfo> {
         return .init(self) { viewController, userInfo in
-            // UserInfo 가 필요한 곳에 데이터 매핑
-            userInfo.defaultItems.forEach{ item in
+            userInfo.defaultItems.forEach { item in
                 let profileInfo: ProfileInfoComponent = .init(userInfoItem: item)
                 self.vStackLayout.addArrangedSubview(profileInfo)
             }
@@ -140,13 +139,11 @@ private extension HomeViewController {
                 make.centerX.equalTo(self.view.safeAreaLayoutGuide)
                 make.top.equalTo(self.profileImageView.snp.bottom).offset(20)
             }
-            print(userInfo.name)
         }
     }
     
     var cvsInfoBinding: Binder<[CVInfo]> {
         return .init(self) { viewController, cvsInfo in
-            // CVsInfo 가 필요한 곳에 데이터 매핑
             cvsInfo.forEach { cvInfo in
                 let cvCard = CVCard()
                 cvCard.cvTitle.text = cvInfo.title


### PR DESCRIPTION
## 변경점 설명
<!-- 필요 시 작성 -->
- Home화면에 표시할 정보의 수를 6개에서 4개로 변경
- 데이터를 바인딩하여 화면에 출력

## 참고 자료
<!-- 필요 시 작성 -->
<!-- 이미지, 링크, 플로우차트 등등 -->
![스크린샷 2022-12-08 오후 8 49 54](https://user-images.githubusercontent.com/70786167/206439438-096f22d4-e41b-4370-a015-73728c93a357.png)


## PR Checklist
<!-- 만족하는 항목은 [ ] 안에 "x" 를 입력해주세요. (ex: [x]) -->
<!-- 꼭!!! 체크하기 전에 다시 한번 확인해주세요!! -->

- [x] 변경 사항을 적용하고 빌드&테스트 실행을 해봤나요?
<!-- - [ ] [Code Convention](https://il-gob.notion.site/Code-Convention-29ce0d4e48e440b9bc74b1a19c99b57b)을 준수했나요? -->
