### PR TITLE
:zap: 프로필 수정 화면 이동의 내부 구현 변경

### DIFF
--- a/ItsME/Entities/UserInfo.swift
+++ b/ItsME/Entities/UserInfo.swift
@@ -69,3 +69,19 @@ extension UserInfo {
         case educationItems
     }
 }
+
+extension UserInfo {
+    
+    static var empty: UserInfo {
+        .init(
+            name: "",
+            profileImageURL: "",
+            birthday: .empty,
+            address: .empty,
+            phoneNumber: .empty,
+            email: .empty,
+            otherItems: [],
+            educationItems: []
+        )
+    }
+}

--- a/ItsME/Entities/UserInfoItem.swift
+++ b/ItsME/Entities/UserInfoItem.swift
@@ -59,3 +59,10 @@ extension UserInfoItem {
         case contents
     }
 }
+
+extension UserInfoItem {
+    
+    static var empty: UserInfoItem {
+        .init(icon: .default, contents: "")
+    }
+}

--- a/ItsME/Presentation/Scenes/EditProfile/EditProfileViewController.swift
+++ b/ItsME/Presentation/Scenes/EditProfile/EditProfileViewController.swift
@@ -14,7 +14,7 @@ final class EditProfileViewController: UIViewController {
     
     private let disposeBag: DisposeBag = .init()
     
-    var viewModel: EditProfileViewModel!
+    private let viewModel: EditProfileViewModel
     
     // MARK: - UI Components
     
@@ -82,6 +82,17 @@ final class EditProfileViewController: UIViewController {
     private lazy var educationItemAddButton: ItemAddButton = .init()
     
     private lazy var editingCompleteButton: UIBarButtonItem = .init(title: "수정완료")
+    
+    // MARK: - Initializer
+    
+    init(viewModel: EditProfileViewModel) {
+        self.viewModel = viewModel
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
     
     // MARK: - Life Cycle
     
@@ -287,7 +298,8 @@ struct EditProfileViewControllerRepresenter: UIViewControllerRepresentable {
     
     func makeUIViewController(context: Context) -> UIViewController {
         let navigationController: UINavigationController = .init(rootViewController: .init())
-        let editProfileViewController: EditProfileViewController = .init()
+        let editProfileViewModel: EditProfileViewModel = .init(userInfo: .empty)
+        let editProfileViewController: EditProfileViewController = .init(viewModel: editProfileViewModel)
         navigationController.pushViewController(editProfileViewController, animated: false)
         return navigationController
     }

--- a/ItsME/Presentation/Scenes/EditProfile/EditProfileViewController.swift
+++ b/ItsME/Presentation/Scenes/EditProfile/EditProfileViewController.swift
@@ -117,9 +117,7 @@ private extension EditProfileViewController {
         let output = viewModel.transform(input: input)
         
         output.userName
-            .drive(with: self, onNext: { (owner, userName) in
-                owner.nameTextField.text = userName
-            })
+            .drive(nameTextField.rx.text)
             .disposed(by: disposeBag)
         
         output.userInfoItems

--- a/ItsME/Presentation/Scenes/EditProfile/EditProfileViewController.swift
+++ b/ItsME/Presentation/Scenes/EditProfile/EditProfileViewController.swift
@@ -121,8 +121,8 @@ private extension EditProfileViewController {
             .disposed(by: disposeBag)
         
         output.userInfoItems
-            .drive(onNext: { userInfoItems in
-                self.totalUserInfoItemStackView.bind(userInfoItems: userInfoItems)
+            .drive(with: self, onNext: { owner, userInfoItems in
+                owner.totalUserInfoItemStackView.bind(userInfoItems: userInfoItems)
             })
             .disposed(by: disposeBag)
         

--- a/ItsME/Presentation/Scenes/EditProfile/EditProfileViewController.swift
+++ b/ItsME/Presentation/Scenes/EditProfile/EditProfileViewController.swift
@@ -14,7 +14,7 @@ final class EditProfileViewController: UIViewController {
     
     private let disposeBag: DisposeBag = .init()
     
-    private let viewModel: EditProfileViewModel = .init()
+    var viewModel: EditProfileViewModel!
     
     // MARK: - UI Components
     
@@ -109,7 +109,6 @@ private extension EditProfileViewController {
     
     func bindViewModel() {
         let input = EditProfileViewModel.Input.init(
-            viewDidLoad: .just(()),
             tapEditingCompleteButton: editingCompleteButton.rx.tap.asSignal()
                 .withUnretained(self)
                 .map { (owner, _) in owner.makeCurrentUserInfo() }

--- a/ItsME/Presentation/Scenes/EditProfile/EditProfileViewModel.swift
+++ b/ItsME/Presentation/Scenes/EditProfile/EditProfileViewModel.swift
@@ -11,7 +11,6 @@ import RxCocoa
 final class EditProfileViewModel: ViewModelType {
     
     struct Input {
-        let viewDidLoad: Signal<Void>
         let tapEditingCompleteButton: Signal<UserInfo>
     }
     
@@ -24,19 +23,18 @@ final class EditProfileViewModel: ViewModelType {
     
     private let userRepository: UserRepository = .init()
     
-    private let educationItemsRelay: BehaviorRelay<[EducationItem]> = .init(value: [])
+    private let userInfoRelay: BehaviorRelay<UserInfo>
+    
+    init(userInfo: UserInfo) {
+        self.userInfoRelay = .init(value: userInfo)
+    }
     
     func transform(input: Input) -> Output {
-        let userInfo = input.viewDidLoad
-            .flatMapLatest { _ -> Driver<UserInfo> in
-                self.userRepository.getUserInfo(byUID: "testUser") // FIXME: 유저 고유 ID 저장 방안 필요
-                    .asDriverOnErrorJustComplete()
-            }
-            .do(onNext: initializeEducationItemsRelay)
-        let userName = userInfo.map { $0.name }
-        let userInfoItems = userInfo.map { $0.defaultItems + $0.otherItems }
-        let educationItems = educationItemsRelay.asDriver()
+        let userInfoDriver = userInfoRelay.asDriver()
         
+        let userName = userInfoDriver.map { $0.name }
+        let userInfoItems = userInfoDriver.map { $0.defaultItems + $0.otherItems }
+        let educationItems = userInfoDriver.map { $0.educationItems }
         let tappedEditingCompleteButton = input.tapEditingCompleteButton
             .do(onNext: { userInfo in
                 // TODO: 유저 정보 저장
@@ -57,17 +55,20 @@ final class EditProfileViewModel: ViewModelType {
 extension EditProfileViewModel {
     
     func deleteEducationItem(at indexPath: IndexPath) {
-        var educationItems = educationItemsRelay.value
+        let userInfo = userInfoRelay.value
+        var educationItems = userInfo.educationItems
         educationItems.remove(at: indexPath.row)
-        educationItemsRelay.accept(educationItems)
-    }
-}
-
-// MARK: - Private Functions
-
-private extension EditProfileViewModel {
-    
-    func initializeEducationItemsRelay(_ userInfo: UserInfo) {
-        educationItemsRelay.accept(userInfo.educationItems)
+        
+        let newUserInfo: UserInfo = .init(
+            name: userInfo.name,
+            profileImageURL: userInfo.profileImageURL,
+            birthday: userInfo.birthday,
+            address: userInfo.address,
+            phoneNumber: userInfo.phoneNumber,
+            email: userInfo.email,
+            otherItems: userInfo.otherItems,
+            educationItems: educationItems
+        )
+        userInfoRelay.accept(newUserInfo)
     }
 }

--- a/ItsME/Presentation/Scenes/EditProfile/OtherItemEditing/OtherItemEditingViewController.swift
+++ b/ItsME/Presentation/Scenes/EditProfile/OtherItemEditing/OtherItemEditingViewController.swift
@@ -5,12 +5,33 @@
 //  Created by Jaewon Yun on 2023/01/10.
 //
 
+import SnapKit
+import Then
 import UIKit
 
 final class OtherItemEditingViewController: UIViewController {
     
+    
+    
+    private lazy var completeButton: UIBarButtonItem = .init(title: "완료")
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         self.view.backgroundColor = .systemBackground
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        configureNavigationBar()
+    }
+}
+
+// MARK: - Private Functions
+
+private extension OtherItemEditingViewController {
+    
+    func configureNavigationBar() {
+        self.navigationItem.title = "새 항목"
+        self.navigationItem.rightBarButtonItem = completeButton
     }
 }

--- a/ItsME/Presentation/Scenes/Home/HomeViewController.swift
+++ b/ItsME/Presentation/Scenes/Home/HomeViewController.swift
@@ -23,7 +23,9 @@ final class HomeViewController: UIViewController, UIScrollViewDelegate {
     
     private lazy var editProfileButton: UIButton = {
         let action = UIAction { _ in
+            let editProfileVM: EditProfileViewModel = .init(userInfo: self.viewModel.userInfo)
             let editProfileVC: EditProfileViewController = .init()
+            editProfileVC.viewModel = editProfileVM
             self.navigationController?.pushViewController(editProfileVC, animated: true)
         }
         

--- a/ItsME/Presentation/Scenes/Home/HomeViewController.swift
+++ b/ItsME/Presentation/Scenes/Home/HomeViewController.swift
@@ -24,8 +24,7 @@ final class HomeViewController: UIViewController, UIScrollViewDelegate {
     private lazy var editProfileButton: UIButton = {
         let action = UIAction { _ in
             let editProfileVM: EditProfileViewModel = .init(userInfo: self.viewModel.userInfo)
-            let editProfileVC: EditProfileViewController = .init()
-            editProfileVC.viewModel = editProfileVM
+            let editProfileVC: EditProfileViewController = .init(viewModel: editProfileVM)
             self.navigationController?.pushViewController(editProfileVC, animated: true)
         }
         

--- a/ItsME/Presentation/Scenes/Home/HomeViewModel.swift
+++ b/ItsME/Presentation/Scenes/Home/HomeViewModel.swift
@@ -23,11 +23,14 @@ final class HomeViewModel: ViewModelType {
     private let userRepository: UserRepository = .init()
     private let cvRepository: CVRepository = .init()
     
+    private(set) var userInfo: UserInfo = .empty
+    
     func transform(input: Input) -> Output {
         let userInfo = Signal.merge(input.viewDidLoad, input.viewWillAppear.skip(1))
             .flatMap { _ in
                 return self.userRepository.getUserInfo(byUID: "testUser")
                     .asDriver(onErrorDriveWith: .empty())
+                    .do(onNext: { self.userInfo = $0 })
             }
         
         let cvInfo = Signal.merge(input.viewDidLoad, input.viewWillAppear.skip(1))


### PR DESCRIPTION
## 변경점 설명
<!-- 필요 시 작성 -->
- 빈 엔티티 생성 코드 작성
- 간단한 순환참조 문제 해결 (EditProfileViewController: 123라인)
- 프로필 수정 화면을 넘어갈때 새로 통신을 통해 데이터를 받아올 필요가 없으므로 Home 에서 가지고 있던 데이터를 이용해 화면 연결하도록 구현 변경

## 참고 자료
<!-- 필요 시 작성 -->
<!-- 이미지, 링크, 플로우차트 등등 -->
- 순환 참조 문제 해결에 대한 자세한 설명글 (추천! https://phillip5094.tistory.com/108)

## PR Checklist
<!-- 만족하는 항목은 [ ] 안에 "x" 를 입력해주세요. (ex: [x]) -->
<!-- 꼭!!! 체크하기 전에 다시 한번 확인해주세요!! -->

- [x] 변경 사항을 적용하고 빌드&테스트 실행을 해봤나요?
<!-- - [ ] [Code Convention](https://il-gob.notion.site/Code-Convention-29ce0d4e48e440b9bc74b1a19c99b57b)을 준수했나요? -->
