### PR TITLE
:construction: :sparkles: (feature/totalCV) 카테고리 테이블 컴포넌트 생성 #80

### DIFF
--- a/ItsME.xcodeproj/project.pbxproj
+++ b/ItsME.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		D09AC9812918DE8C0081C0EC /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = D09AC97F2918DE8C0081C0EC /* LaunchScreen.storyboard */; };
 		D09AC98C2918DE8C0081C0EC /* ItsMETests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D09AC98B2918DE8C0081C0EC /* ItsMETests.swift */; };
 		D09AC9982918DE8C0081C0EC /* ItsMEUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D09AC9972918DE8C0081C0EC /* ItsMEUITestsLaunchTests.swift */; };
+		D0B1BA862988DA75003ACD41 /* CategoryCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0B1BA852988DA75003ACD41 /* CategoryCell.swift */; };
 		D0CCF4E12925FB0100AD4AE6 /* UIView+.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0CCF4E02925FB0100AD4AE6 /* UIView+.swift */; };
 		D0CCF4E3292604BE00AD4AE6 /* UIColor+.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0CCF4E2292604BE00AD4AE6 /* UIColor+.swift */; };
 		D0CCF4E629260C2B00AD4AE6 /* ProfileInfoComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0CCF4E529260C2B00AD4AE6 /* ProfileInfoComponent.swift */; };
@@ -102,6 +103,7 @@
 		D09AC9912918DE8C0081C0EC /* ItsMEUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ItsMEUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		D09AC9952918DE8C0081C0EC /* ItsMEUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItsMEUITests.swift; sourceTree = "<group>"; };
 		D09AC9972918DE8C0081C0EC /* ItsMEUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItsMEUITestsLaunchTests.swift; sourceTree = "<group>"; };
+		D0B1BA852988DA75003ACD41 /* CategoryCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryCell.swift; sourceTree = "<group>"; };
 		D0CCF4E02925FB0100AD4AE6 /* UIView+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+.swift"; sourceTree = "<group>"; };
 		D0CCF4E2292604BE00AD4AE6 /* UIColor+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+.swift"; sourceTree = "<group>"; };
 		D0CCF4E529260C2B00AD4AE6 /* ProfileInfoComponent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileInfoComponent.swift; sourceTree = "<group>"; };
@@ -459,6 +461,7 @@
 			isa = PBXGroup;
 			children = (
 				DAFCFB6B294C3666006B287A /* EducationCell.swift */,
+				D0B1BA852988DA75003ACD41 /* CategoryCell.swift */,
 			);
 			path = Cells;
 			sourceTree = "<group>";
@@ -764,6 +767,7 @@
 				DAE6090B2942095400481742 /* TotalUserInfoItemStackView.swift in Sources */,
 				D0CCF504292CCB4C00AD4AE6 /* CVCard.swift in Sources */,
 				DA01880D296D1477002C5CB0 /* PhoneNumberEditingViewController.swift in Sources */,
+				D0B1BA862988DA75003ACD41 /* CategoryCell.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ItsME/Entities/ResumeItem.swift
+++ b/ItsME/Entities/ResumeItem.swift
@@ -9,10 +9,14 @@ import Foundation
 
 final class ResumeItem: Decodable {
     let period: String
-    let contents: String
+    let title: String
+    let secondTitle: String
+    let description: String
     
-    init(period: String, contents: String) {
+    init(period: String, title: String, secondTitle: String, description: String) {
         self.period = period
-        self.contents = contents
+        self.title = title
+        self.secondTitle = secondTitle
+        self.description = description
     }
 }

--- a/ItsME/Presentation/Common/Cells/CategoryCell.swift
+++ b/ItsME/Presentation/Common/Cells/CategoryCell.swift
@@ -1,0 +1,105 @@
+//
+//  CategoryCell.swift
+//  ItsME
+//
+//  Created by MacBook Air on 2023/01/31.
+//
+
+import SnapKit
+import Then
+import UIKit
+
+class CategoryCell: UITableViewCell {
+    
+    static let reuseIdentifier: String = .init(describing: CategoryCell.self)
+    
+    //MARK: - UI Component
+    private lazy var periodLabel = UILabel().then {
+        $0.text = "기간"
+        $0.numberOfLines = 2
+        $0.textColor = .label
+    }
+    
+    private lazy var titleLabel = UILabel().then {
+        $0.text = "제목"
+        $0.textColor = .label
+        $0.font = .boldSystemFont(ofSize: 20)
+    }
+    
+    private lazy var secondTitleLabel = UILabel().then {
+        $0.text = "부제목"
+        $0.textColor = .label
+        $0.font = .systemFont(ofSize: 15, weight: .light)
+    }
+    
+    private lazy var descriptionLabel = UILabel().then {
+        $0.text = "상세설명"
+        $0.numberOfLines = 0
+        $0.textColor = .label
+        $0.font = .boldSystemFont(ofSize: 15)
+    }
+    
+    override func awakeFromNib() {
+        super.awakeFromNib()
+        fatalError("awakeFromNib() has not been implemented")
+    }
+    
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        configureSubviews()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func setSelected(_ selected: Bool, animated: Bool) {
+        super.setSelected(selected, animated: animated)
+        
+        // Configure the view for the selected state
+    }
+    
+    func bind(resumeItem: ResumeItem) {
+        periodLabel.text = resumeItem.period
+        titleLabel.text = resumeItem.title
+        secondTitleLabel.text = resumeItem.secondTitle
+        descriptionLabel.text = resumeItem.description
+    }
+}
+
+// MARK: - Private Functions
+
+private extension CategoryCell {
+    
+    func configureSubviews() {
+        
+        self.contentView.addSubview(periodLabel)
+        periodLabel.snp.makeConstraints { make in
+            make.top.leading.bottom.equalToSuperview()
+        }
+        
+        self.contentView.addSubview(titleLabel)
+        titleLabel.snp.makeConstraints { make in
+            make.top.trailing.equalToSuperview()
+            make.leading.equalTo(periodLabel.snp.trailing).offset(15)
+            make.width.equalTo(periodLabel.snp.width).multipliedBy(2.5)
+            make.width.equalTo(secondTitleLabel.snp.width)
+            make.width.equalTo(descriptionLabel.snp.width)
+            
+        }
+        
+        self.contentView.addSubview(secondTitleLabel)
+        secondTitleLabel.snp.makeConstraints { make in
+            make.trailing.equalToSuperview()
+            make.leading.equalTo(periodLabel.snp.trailing).offset(15)
+            make.top.equalTo(titleLabel.snp.bottom).offset(10)
+        }
+        
+        self.contentView.addSubview(descriptionLabel)
+        descriptionLabel.snp.makeConstraints { make in
+            make.trailing.bottom.equalToSuperview()
+            make.leading.equalTo(periodLabel.snp.trailing).offset(15)
+            make.top.equalTo(secondTitleLabel.snp.bottom).offset(10)
+        }
+    }
+}

--- a/ItsME/Presentation/Scenes/TotalCV/TotalCVViewController.swift
+++ b/ItsME/Presentation/Scenes/TotalCV/TotalCVViewController.swift
@@ -49,6 +49,22 @@ class TotalCVViewController: UIViewController {
         $0.register(cellType, forCellReuseIdentifier: cellType.reuseIdentifier)
     }
     
+    private lazy var categoryTableView: IntrinsicHeightTableView = .init().then {
+        $0.delegate = self
+        $0.backgroundColor = .systemBackground
+        $0.isScrollEnabled = false
+        $0.separatorInset = .zero
+        $0.isUserInteractionEnabled = false
+        let cellType = CategoryCell.self
+        $0.register(cellType, forCellReuseIdentifier: cellType.reuseIdentifier)
+    }
+    
+    private lazy var coverLetterLabel: UILabel = .init().then {
+        $0.text = "자기소개서"
+        $0.font = .boldSystemFont(ofSize: 26)
+        $0.textColor = .systemBlue
+    }
+    
     let label = UILabel().then {
         $0.textAlignment = .center
         $0.textColor = .systemBlue
@@ -78,6 +94,7 @@ class TotalCVViewController: UIViewController {
     func configureNavigationBar() {
         self.navigationController?.setNavigationBarHidden(false, animated: true)
         navigationController?.navigationBar.prefersLargeTitles = true
+        self.navigationItem.largeTitleDisplayMode = .always
         UILabel.appearance(whenContainedInInstancesOf: [UINavigationBar.self]).adjustsFontSizeToFitWidth = true
         
     }
@@ -176,7 +193,13 @@ private extension TotalCVViewController {
         self.contentView.addSubview(educationTableView)
         educationTableView.snp.makeConstraints { make in
             make.top.equalTo(educationHeaderLabel.snp.bottom).offset(10)
-            make.left.right.equalToSuperview().inset(24)
+            make.leading.trailing.equalToSuperview().inset(24)
+        }
+        
+        self.contentView.addSubview(coverLetterLabel)
+        coverLetterLabel.snp.makeConstraints { make in
+            make.leading.trailing.equalToSuperview().inset(20)
+            make.top.equalTo(educationTableView.snp.bottom).offset(30)
         }
         
         self.contentView.addSubview(label)

--- a/ItsME/Presentation/Scenes/TotalCV/TotalCVViewModel.swift
+++ b/ItsME/Presentation/Scenes/TotalCV/TotalCVViewModel.swift
@@ -46,7 +46,7 @@ final class TotalCVViewModel: ViewModelType {
         
         return .init(
             userInfoItems: userInfoItems,
-            educationItems:educationItems,
+            educationItems: educationItems,
             cvInfo: cvInfo
         )
     }


### PR DESCRIPTION
## 변경점 설명
<!-- 필요 시 작성 -->
- 카테고리를 추가할 때 사용하는 테이블뷰에 대한 컴포넌트 생성
- ResumeItem에 기간과 설명만 정의 되어 있어서 제목과 부제목을 추가
- ResumeItem의 변수 명[context]을 -> description으로 더욱 직관적으로 변경

## 참고 자료
<!-- 필요 시 작성 -->
<!-- 이미지, 링크, 플로우차트 등등 -->


## PR Checklist
<!-- 만족하는 항목은 [ ] 안에 "x" 를 입력해주세요. (ex: [x]) -->
<!-- 꼭!!! 체크하기 전에 다시 한번 확인해주세요!! -->

- [x] 변경 사항을 적용하고 빌드&테스트 실행을 해봤나요?
<!-- - [ ] [Code Convention](https://il-gob.notion.site/Code-Convention-29ce0d4e48e440b9bc74b1a19c99b57b)을 준수했나요? -->
