### PR TITLE
:construction: 프로필 수정 화면의 전체적인 UI 개선

### DIFF
--- a/ItsME.xcodeproj/project.pbxproj
+++ b/ItsME.xcodeproj/project.pbxproj
@@ -50,6 +50,7 @@
 		DA739DE62925E35A003AEE4C /* ItsMEUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D09AC9952918DE8C0081C0EC /* ItsMEUITests.swift */; };
 		DAA5B9652938825A00BAB04E /* EditProfileViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAA5B9642938825A00BAB04E /* EditProfileViewController.swift */; };
 		DAA5B9672938827200BAB04E /* EditProfileViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAA5B9662938827200BAB04E /* EditProfileViewModel.swift */; };
+		DAAB20C1299B6AEF00D5338D /* Reusable.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAAB20C0299B6AEF00D5338D /* Reusable.swift */; };
 		DAAC7A5C29715C0A0083A8E9 /* Rx+Ext.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAAC7A5B29715C0A0083A8E9 /* Rx+Ext.swift */; };
 		DAAF1BD7299A0E1100728376 /* NewOtherItemViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAAF1BD6299A0E1100728376 /* NewOtherItemViewController.swift */; };
 		DAAF1BDC299A11F400728376 /* UserInfoItemInputView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAAF1BDB299A11F400728376 /* UserInfoItemInputView.swift */; };
@@ -140,6 +141,7 @@
 		DA739DE32924FE54003AEE4C /* CommonAlertViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommonAlertViewController.swift; sourceTree = "<group>"; };
 		DAA5B9642938825A00BAB04E /* EditProfileViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditProfileViewController.swift; sourceTree = "<group>"; };
 		DAA5B9662938827200BAB04E /* EditProfileViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditProfileViewModel.swift; sourceTree = "<group>"; };
+		DAAB20C0299B6AEF00D5338D /* Reusable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Reusable.swift; sourceTree = "<group>"; };
 		DAAC7A5B29715C0A0083A8E9 /* Rx+Ext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Rx+Ext.swift"; sourceTree = "<group>"; };
 		DAAF1BD6299A0E1100728376 /* NewOtherItemViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewOtherItemViewController.swift; sourceTree = "<group>"; };
 		DAAF1BDB299A11F400728376 /* UserInfoItemInputView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserInfoItemInputView.swift; sourceTree = "<group>"; };
@@ -510,6 +512,7 @@
 			children = (
 				DAB06A3F291BA61100E86163 /* ViewModelType.swift */,
 				D0CCF4E2292604BE00AD4AE6 /* UIColor+.swift */,
+				DAAB20C0299B6AEF00D5338D /* Reusable.swift */,
 			);
 			path = Protocols;
 			sourceTree = "<group>";
@@ -771,6 +774,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				DAAB20C1299B6AEF00D5338D /* Reusable.swift in Sources */,
 				DAE6090D29420D9900481742 /* ItemAddButton.swift in Sources */,
 				DAAF1BDF299A1E8100728376 /* Array+SafeIndex.swift in Sources */,
 				DAA5B9652938825A00BAB04E /* EditProfileViewController.swift in Sources */,

--- a/ItsME.xcodeproj/project.pbxproj
+++ b/ItsME.xcodeproj/project.pbxproj
@@ -50,7 +50,10 @@
 		DA739DE62925E35A003AEE4C /* ItsMEUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D09AC9952918DE8C0081C0EC /* ItsMEUITests.swift */; };
 		DAA5B9652938825A00BAB04E /* EditProfileViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAA5B9642938825A00BAB04E /* EditProfileViewController.swift */; };
 		DAA5B9672938827200BAB04E /* EditProfileViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAA5B9662938827200BAB04E /* EditProfileViewModel.swift */; };
+		DAAB20BF299B682900D5338D /* UserInfoItemInputTableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAAB20BE299B682900D5338D /* UserInfoItemInputTableView.swift */; };
 		DAAB20C1299B6AEF00D5338D /* Reusable.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAAB20C0299B6AEF00D5338D /* Reusable.swift */; };
+		DAAB20C5299B7A1000D5338D /* IconInputCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAAB20C4299B7A1000D5338D /* IconInputCell.swift */; };
+		DAAB20C7299B7A5600D5338D /* ContentsInputCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAAB20C6299B7A5600D5338D /* ContentsInputCell.swift */; };
 		DAAC7A5C29715C0A0083A8E9 /* Rx+Ext.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAAC7A5B29715C0A0083A8E9 /* Rx+Ext.swift */; };
 		DAAF1BD7299A0E1100728376 /* NewOtherItemViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAAF1BD6299A0E1100728376 /* NewOtherItemViewController.swift */; };
 		DAAF1BDC299A11F400728376 /* UserInfoItemInputView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAAF1BDB299A11F400728376 /* UserInfoItemInputView.swift */; };
@@ -141,7 +144,10 @@
 		DA739DE32924FE54003AEE4C /* CommonAlertViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommonAlertViewController.swift; sourceTree = "<group>"; };
 		DAA5B9642938825A00BAB04E /* EditProfileViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditProfileViewController.swift; sourceTree = "<group>"; };
 		DAA5B9662938827200BAB04E /* EditProfileViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditProfileViewModel.swift; sourceTree = "<group>"; };
+		DAAB20BE299B682900D5338D /* UserInfoItemInputTableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserInfoItemInputTableView.swift; sourceTree = "<group>"; };
 		DAAB20C0299B6AEF00D5338D /* Reusable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Reusable.swift; sourceTree = "<group>"; };
+		DAAB20C4299B7A1000D5338D /* IconInputCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IconInputCell.swift; sourceTree = "<group>"; };
+		DAAB20C6299B7A5600D5338D /* ContentsInputCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentsInputCell.swift; sourceTree = "<group>"; };
 		DAAC7A5B29715C0A0083A8E9 /* Rx+Ext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Rx+Ext.swift"; sourceTree = "<group>"; };
 		DAAF1BD6299A0E1100728376 /* NewOtherItemViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewOtherItemViewController.swift; sourceTree = "<group>"; };
 		DAAF1BDB299A11F400728376 /* UserInfoItemInputView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserInfoItemInputView.swift; sourceTree = "<group>"; };
@@ -405,6 +411,23 @@
 			path = EditProfile;
 			sourceTree = "<group>";
 		};
+		DAAB20C2299B79E400D5338D /* TableView */ = {
+			isa = PBXGroup;
+			children = (
+				DAAB20BE299B682900D5338D /* UserInfoItemInputTableView.swift */,
+			);
+			path = TableView;
+			sourceTree = "<group>";
+		};
+		DAAB20C3299B79E900D5338D /* Cell */ = {
+			isa = PBXGroup;
+			children = (
+				DAAB20C4299B7A1000D5338D /* IconInputCell.swift */,
+				DAAB20C6299B7A5600D5338D /* ContentsInputCell.swift */,
+			);
+			path = Cell;
+			sourceTree = "<group>";
+		};
 		DAAF1BD5299A0DF300728376 /* NewOtherItem */ = {
 			isa = PBXGroup;
 			children = (
@@ -426,6 +449,8 @@
 		DAAF1BDD299A11FE00728376 /* CommonView */ = {
 			isa = PBXGroup;
 			children = (
+				DAAB20C3299B79E900D5338D /* Cell */,
+				DAAB20C2299B79E400D5338D /* TableView */,
 				DAAF1BDB299A11F400728376 /* UserInfoItemInputView.swift */,
 			);
 			path = CommonView;
@@ -777,7 +802,9 @@
 				DAAB20C1299B6AEF00D5338D /* Reusable.swift in Sources */,
 				DAE6090D29420D9900481742 /* ItemAddButton.swift in Sources */,
 				DAAF1BDF299A1E8100728376 /* Array+SafeIndex.swift in Sources */,
+				DAAB20C5299B7A1000D5338D /* IconInputCell.swift in Sources */,
 				DAA5B9652938825A00BAB04E /* EditProfileViewController.swift in Sources */,
+				DAAB20C7299B7A5600D5338D /* ContentsInputCell.swift in Sources */,
 				DAAFB2532918EE5A007A8DF0 /* UserInfo.swift in Sources */,
 				DAFCFB6C294C3666006B287A /* EducationCell.swift in Sources */,
 				DA7201EC29309B9600A69519 /* AuthenticationServices+Rx.swift in Sources */,
@@ -787,6 +814,7 @@
 				DAAC7A5C29715C0A0083A8E9 /* Rx+Ext.swift in Sources */,
 				DAFCFB67294AC00C006B287A /* UIStackView+.swift in Sources */,
 				DA7201FA2931F90900A69519 /* Resume.swift in Sources */,
+				DAAB20BF299B682900D5338D /* UserInfoItemInputTableView.swift in Sources */,
 				DA0A88692921245000E9AE43 /* UserRepository.swift in Sources */,
 				D0CCF4E12925FB0100AD4AE6 /* UIView+.swift in Sources */,
 				D0CCF4E629260C2B00AD4AE6 /* ProfileInfoComponent.swift in Sources */,

--- a/ItsME/Presentation/Common/Cells/CategoryCell.swift
+++ b/ItsME/Presentation/Common/Cells/CategoryCell.swift
@@ -11,8 +11,6 @@ import UIKit
 
 class CategoryCell: UITableViewCell {
     
-    static let reuseIdentifier: String = .init(describing: CategoryCell.self)
-    
     //MARK: - UI Component
     private lazy var periodLabel = UILabel().then {
         $0.text = "기간"

--- a/ItsME/Presentation/Common/Cells/EducationCell.swift
+++ b/ItsME/Presentation/Common/Cells/EducationCell.swift
@@ -67,20 +67,26 @@ private extension EducationCell {
         self.contentView.addSubview(titleLabel)
         self.contentView.addSubview(descriptionLabel)
         
+        let verticalInsetValue = 4
+        let horizontalInsetValue = 12
+        
         periodLabel.snp.makeConstraints { make in
-            make.top.left.bottom.equalToSuperview()
+            make.top.bottom.equalToSuperview().inset(verticalInsetValue)
+            make.leading.equalToSuperview().inset(horizontalInsetValue)
         }
         
         titleLabel.snp.makeConstraints { make in
-            make.top.right.equalToSuperview()
-            make.left.equalTo(periodLabel.snp.right).offset(12)
+            make.leading.trailing.equalTo(descriptionLabel)
+            make.top.equalToSuperview().inset(verticalInsetValue)
+            make.trailing.equalToSuperview().inset(horizontalInsetValue)
             make.bottom.equalTo(descriptionLabel.snp.top)
-            make.width.equalTo(descriptionLabel.snp.width)
-            make.width.equalTo(periodLabel.snp.width).multipliedBy(2.5)
+            make.leading.equalTo(periodLabel.snp.trailing).offset(14)
+            make.width.equalTo(periodLabel).multipliedBy(2.3)
         }
         
         descriptionLabel.snp.makeConstraints { make in
-            make.right.bottom.equalToSuperview()
+            make.bottom.equalToSuperview().inset(verticalInsetValue)
+            make.trailing.equalToSuperview().inset(horizontalInsetValue)
         }
     }
 }

--- a/ItsME/Presentation/Common/Cells/EducationCell.swift
+++ b/ItsME/Presentation/Common/Cells/EducationCell.swift
@@ -11,8 +11,6 @@ import UIKit
 
 final class EducationCell: UITableViewCell {
 
-    static let reuseIdentifier: String = .init(describing: EducationCell.self)
-    
     // MARK: - UI Components
     
     private lazy var periodLabel: UILabel = {

--- a/ItsME/Presentation/Common/Component/TotalUserInfoItemStackView.swift
+++ b/ItsME/Presentation/Common/Component/TotalUserInfoItemStackView.swift
@@ -24,10 +24,12 @@ final class TotalUserInfoItemStackView: UIStackView {
         self.backgroundColor = .clear
         
         self.axis = .vertical
-        self.spacing = 8
+        let spacing: CGFloat = 8.0
+        self.spacing = spacing
         self.alignment = .fill
         self.distribution = .equalSpacing
-        
+        self.directionalLayoutMargins = .init(top: spacing / 2, leading: spacing / 2, bottom: spacing / 2, trailing: spacing / 2)
+        self.isLayoutMarginsRelativeArrangement = true
         
         bind(userInfoItems: [])
     }

--- a/ItsME/Presentation/Common/TableView/IntrinsicHeightTableView.swift
+++ b/ItsME/Presentation/Common/TableView/IntrinsicHeightTableView.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-final class IntrinsicHeightTableView: UITableView {
+class IntrinsicHeightTableView: UITableView {
     
     override var intrinsicContentSize: CGSize {
         return .init(

--- a/ItsME/Presentation/Scenes/EditProfile/EditProfileViewController.swift
+++ b/ItsME/Presentation/Scenes/EditProfile/EditProfileViewController.swift
@@ -57,6 +57,9 @@ final class EditProfileViewController: UIViewController {
     
     private lazy var totalUserInfoItemStackView: UserInfoItemStackView = .init().then {
         $0.hasSeparator = true
+        $0.backgroundColor = .systemBackground
+        $0.layer.masksToBounds = true
+        $0.layer.cornerRadius = 12.0
     }
     
     private lazy var userInfoItemAddButton: ItemAddButton = .init().then {
@@ -199,7 +202,7 @@ private extension EditProfileViewController {
         self.contentView.addSubview(totalUserInfoItemStackView)
         totalUserInfoItemStackView.snp.makeConstraints { make in
             make.top.equalTo(nameTextField.snp.bottom).offset(25)
-            make.left.right.equalToSuperview().inset(30)
+            make.left.right.equalToSuperview().inset(16)
         }
         
         self.contentView.addSubview(userInfoItemAddButton)

--- a/ItsME/Presentation/Scenes/EditProfile/EditProfileViewController.swift
+++ b/ItsME/Presentation/Scenes/EditProfile/EditProfileViewController.swift
@@ -236,7 +236,7 @@ private extension EditProfileViewController {
     }
     
     func configureNavigationBar() {
-        self.navigationItem.title = "Edit Profile"
+        self.navigationItem.title = "프로필 수정"
         self.navigationItem.rightBarButtonItem = editingCompleteButton
         self.navigationController?.navigationBar.prefersLargeTitles = false
         self.navigationController?.setNavigationBarHidden(false, animated: false)

--- a/ItsME/Presentation/Scenes/EditProfile/EditProfileViewController.swift
+++ b/ItsME/Presentation/Scenes/EditProfile/EditProfileViewController.swift
@@ -75,11 +75,10 @@ final class EditProfileViewController: UIViewController {
         $0.textColor = .systemBlue
     }
     
-    private lazy var educationTableView: IntrinsicHeightTableView = .init().then {
+    private lazy var educationTableView: IntrinsicHeightTableView = .init(frame: .zero, style: .insetGrouped).then {
         $0.delegate = self
-        $0.backgroundColor = .systemBackground
+        $0.backgroundColor = .clear
         $0.isScrollEnabled = false
-        $0.separatorInset = .zero
         let cellType = EducationCell.self
         $0.register(cellType, forCellReuseIdentifier: cellType.reuseIdentifier)
     }
@@ -202,7 +201,7 @@ private extension EditProfileViewController {
         self.contentView.addSubview(totalUserInfoItemStackView)
         totalUserInfoItemStackView.snp.makeConstraints { make in
             make.top.equalTo(nameTextField.snp.bottom).offset(25)
-            make.left.right.equalToSuperview().inset(16)
+            make.left.right.equalToSuperview().inset(20)
         }
         
         self.contentView.addSubview(userInfoItemAddButton)
@@ -215,19 +214,19 @@ private extension EditProfileViewController {
         
         self.contentView.addSubview(educationHeaderLabel)
         educationHeaderLabel.snp.makeConstraints { make in
-            make.left.right.equalToSuperview().inset(20)
+            make.left.right.equalToSuperview().inset(26)
             make.top.equalTo(userInfoItemAddButton.snp.bottom).offset(20)
         }
         
         self.contentView.addSubview(educationTableView)
         educationTableView.snp.makeConstraints { make in
-            make.top.equalTo(educationHeaderLabel.snp.bottom).offset(10)
-            make.left.right.equalToSuperview().inset(24)
+            make.top.equalTo(educationHeaderLabel.snp.bottom).offset(-26)
+            make.left.right.equalToSuperview()
         }
         
         self.contentView.addSubview(educationItemAddButton)
         educationItemAddButton.snp.makeConstraints { make in
-            make.top.equalTo(educationTableView.snp.bottom).offset(10)
+            make.top.equalTo(educationTableView.snp.bottom).offset(-25)
             make.centerX.equalToSuperview()
             make.bottom.equalToSuperview().offset(-20)
             make.leading.trailing.equalToSuperview().inset(30)

--- a/ItsME/Presentation/Scenes/EditProfile/EditProfileViewController.swift
+++ b/ItsME/Presentation/Scenes/EditProfile/EditProfileViewController.swift
@@ -19,14 +19,14 @@ final class EditProfileViewController: UIViewController {
     // MARK: - UI Components
     
     private lazy var containerScrollView: UIScrollView = .init().then {
-        $0.backgroundColor = .systemBackground
+        $0.backgroundColor = .clear
         $0.showsVerticalScrollIndicator = true
         $0.showsHorizontalScrollIndicator = false
         $0.delegate = self
     }
     
     private lazy var contentView: UIView = .init().then {
-        $0.backgroundColor = .systemBackground
+        $0.backgroundColor = .clear
     }
     
     private lazy var profileImageView: UIImageView = .init(image: .init(named: "테스트이미지")).then {
@@ -102,7 +102,7 @@ final class EditProfileViewController: UIViewController {
         super.viewDidLoad()
         bindViewModel()
         configureSubviews()
-        self.view.backgroundColor = .systemBackground
+        self.view.backgroundColor = .secondarySystemBackground
     }
     
     override func viewWillAppear(_ animated: Bool) {

--- a/ItsME/Presentation/Scenes/EditProfile/OtherItem/CommonView/Cell/ContentsInputCell.swift
+++ b/ItsME/Presentation/Scenes/EditProfile/OtherItem/CommonView/Cell/ContentsInputCell.swift
@@ -1,0 +1,51 @@
+//
+//  ContentsInputCell.swift
+//  ItsME
+//
+//  Created by Jaewon Yun on 2023/02/14.
+//
+
+import SnapKit
+import Then
+import UIKit
+
+final class ContentsInputCell: UITableViewCell {
+    
+    private lazy var titleLabel: UILabel = .init().then {
+        $0.text = "URL"
+    }
+    
+    private lazy var contentsTextField: UITextField = .init().then {
+        $0.font = .systemFont(ofSize: 16.0)
+        $0.placeholder = "http://example.com"
+        $0.autocorrectionType = .no
+        $0.keyboardType = .URL
+        $0.autocapitalizationType = .none
+        $0.clearButtonMode = .whileEditing
+    }
+    
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        configureSubviews()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    private func configureSubviews() {
+        self.contentView.addSubview(titleLabel)
+        titleLabel.snp.makeConstraints { make in
+            make.leading.equalToSuperview().offset(12)
+            make.top.bottom.equalToSuperview()
+            make.height.equalTo(40).priority(999)
+            make.width.equalTo(60)
+        }
+        
+        self.contentView.addSubview(contentsTextField)
+        contentsTextField.snp.makeConstraints { make in
+            make.top.trailing.bottom.equalToSuperview()
+            make.leading.equalTo(titleLabel.snp.trailing).offset(20)
+        }
+    }
+}

--- a/ItsME/Presentation/Scenes/EditProfile/OtherItem/CommonView/Cell/ContentsInputCell.swift
+++ b/ItsME/Presentation/Scenes/EditProfile/OtherItem/CommonView/Cell/ContentsInputCell.swift
@@ -33,6 +33,10 @@ final class ContentsInputCell: UITableViewCell {
         fatalError("init(coder:) has not been implemented")
     }
     
+    override func setSelected(_ selected: Bool, animated: Bool) {
+        super.setSelected(false, animated: false)
+    }
+    
     private func configureSubviews() {
         self.contentView.addSubview(titleLabel)
         titleLabel.snp.makeConstraints { make in

--- a/ItsME/Presentation/Scenes/EditProfile/OtherItem/CommonView/Cell/ContentsInputCell.swift
+++ b/ItsME/Presentation/Scenes/EditProfile/OtherItem/CommonView/Cell/ContentsInputCell.swift
@@ -15,7 +15,7 @@ final class ContentsInputCell: UITableViewCell {
         $0.text = "URL"
     }
     
-    private lazy var contentsTextField: UITextField = .init().then {
+    lazy var contentsTextField: UITextField = .init().then {
         $0.font = .systemFont(ofSize: 16.0)
         $0.placeholder = "http://example.com"
         $0.autocorrectionType = .no

--- a/ItsME/Presentation/Scenes/EditProfile/OtherItem/CommonView/Cell/ContentsInputCell.swift
+++ b/ItsME/Presentation/Scenes/EditProfile/OtherItem/CommonView/Cell/ContentsInputCell.swift
@@ -22,6 +22,7 @@ final class ContentsInputCell: UITableViewCell {
         $0.keyboardType = .URL
         $0.autocapitalizationType = .none
         $0.clearButtonMode = .whileEditing
+        $0.delegate = self
     }
     
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
@@ -51,5 +52,14 @@ final class ContentsInputCell: UITableViewCell {
             make.top.trailing.bottom.equalToSuperview()
             make.leading.equalTo(titleLabel.snp.trailing).offset(20)
         }
+    }
+}
+
+// MARK: - UITextFieldDelegate
+
+extension ContentsInputCell: UITextFieldDelegate {
+    
+    func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+        return textField.resignFirstResponder()
     }
 }

--- a/ItsME/Presentation/Scenes/EditProfile/OtherItem/CommonView/Cell/IconInputCell.swift
+++ b/ItsME/Presentation/Scenes/EditProfile/OtherItem/CommonView/Cell/IconInputCell.swift
@@ -1,0 +1,46 @@
+//
+//  IconInputCell.swift
+//  ItsME
+//
+//  Created by Jaewon Yun on 2023/02/14.
+//
+
+import SnapKit
+import Then
+import UIKit
+
+final class IconInputCell: UITableViewCell {
+    
+    private lazy var titleLabel: UILabel = .init().then {
+        $0.text = "아이콘"
+    }
+    
+    private lazy var iconLabel: UILabel = .init().then {
+        $0.text = UserInfoItemIcon.default.toEmoji
+    }
+    
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        configureSubviews()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    private func configureSubviews() {
+        self.contentView.addSubview(titleLabel)
+        titleLabel.snp.makeConstraints { make in
+            make.leading.equalToSuperview().offset(12)
+            make.top.bottom.equalToSuperview()
+            make.height.equalTo(40).priority(999)
+            make.width.equalTo(60)
+        }
+        
+        self.contentView.addSubview(iconLabel)
+        iconLabel.snp.makeConstraints { make in
+            make.top.trailing.bottom.equalToSuperview()
+            make.leading.equalTo(titleLabel.snp.trailing).offset(20)
+        }
+    }
+}

--- a/ItsME/Presentation/Scenes/EditProfile/OtherItem/CommonView/Cell/IconInputCell.swift
+++ b/ItsME/Presentation/Scenes/EditProfile/OtherItem/CommonView/Cell/IconInputCell.swift
@@ -15,7 +15,7 @@ final class IconInputCell: UITableViewCell {
         $0.text = "아이콘"
     }
     
-    private lazy var iconLabel: UILabel = .init().then {
+    lazy var iconLabel: UILabel = .init().then {
         $0.text = UserInfoItemIcon.default.toEmoji
     }
     

--- a/ItsME/Presentation/Scenes/EditProfile/OtherItem/CommonView/Cell/IconInputCell.swift
+++ b/ItsME/Presentation/Scenes/EditProfile/OtherItem/CommonView/Cell/IconInputCell.swift
@@ -28,6 +28,10 @@ final class IconInputCell: UITableViewCell {
         fatalError("init(coder:) has not been implemented")
     }
     
+    override func setSelected(_ selected: Bool, animated: Bool) {
+        super.setSelected(false, animated: false)
+    }
+    
     private func configureSubviews() {
         self.contentView.addSubview(titleLabel)
         titleLabel.snp.makeConstraints { make in

--- a/ItsME/Presentation/Scenes/EditProfile/OtherItem/CommonView/TableView/UserInfoItemInputTableView.swift
+++ b/ItsME/Presentation/Scenes/EditProfile/OtherItem/CommonView/TableView/UserInfoItemInputTableView.swift
@@ -38,6 +38,11 @@ final class UserInfoItemInputTableView: IntrinsicHeightTableView {
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
+    
+    func bind(userInfoItem: UserInfoItem) {
+        iconInputCell.iconLabel.text = userInfoItem.icon.toEmoji
+        contentsInputCell.contentsTextField.text = userInfoItem.contents
+    }
 }
 
 // MARK: - UITableViewDataSource

--- a/ItsME/Presentation/Scenes/EditProfile/OtherItem/CommonView/TableView/UserInfoItemInputTableView.swift
+++ b/ItsME/Presentation/Scenes/EditProfile/OtherItem/CommonView/TableView/UserInfoItemInputTableView.swift
@@ -1,0 +1,45 @@
+//
+//  UserInfoItemInputTableView.swift
+//  ItsME
+//
+//  Created by Jaewon Yun on 2023/02/14.
+//
+
+import SnapKit
+import Then
+import UIKit
+
+final class UserInfoItemInputTableView: IntrinsicHeightTableView {
+    
+    override init(frame: CGRect, style: UITableView.Style) {
+        super.init(frame: frame, style: style)
+        self.register(IconInputCell.self, forCellReuseIdentifier: IconInputCell.reuseIdentifier)
+        self.register(ContentsInputCell.self, forCellReuseIdentifier: ContentsInputCell.reuseIdentifier)
+        self.dataSource = self
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+// MARK: - UITableViewDataSource
+
+extension UserInfoItemInputTableView: UITableViewDataSource {
+    
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return 2
+    }
+    
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        if indexPath.row == 0 {
+            let cell: IconInputCell = .init(style: .default, reuseIdentifier: IconInputCell.reuseIdentifier)
+            
+            return cell
+        } else {
+            let cell: ContentsInputCell = .init(style: .default, reuseIdentifier: ContentsInputCell.reuseIdentifier)
+            
+            return cell
+        }
+    }
+}

--- a/ItsME/Presentation/Scenes/EditProfile/OtherItem/CommonView/TableView/UserInfoItemInputTableView.swift
+++ b/ItsME/Presentation/Scenes/EditProfile/OtherItem/CommonView/TableView/UserInfoItemInputTableView.swift
@@ -21,6 +21,13 @@ final class UserInfoItemInputTableView: IntrinsicHeightTableView {
         ]
     }
     
+    var currentInputUserInfoItem: UserInfoItem {
+        let emoji = iconInputCell.iconLabel.text ?? UserInfoItemIcon.default.toEmoji
+        let icon: UserInfoItemIcon = .init(rawValue: emoji) ?? .default
+        let contents = contentsInputCell.contentsTextField.text ?? ""
+        return .init(icon: icon, contents: contents)
+    }
+    
     override init(frame: CGRect, style: UITableView.Style) {
         super.init(frame: frame, style: style)
         self.register(IconInputCell.self, forCellReuseIdentifier: IconInputCell.reuseIdentifier)

--- a/ItsME/Presentation/Scenes/EditProfile/OtherItem/CommonView/TableView/UserInfoItemInputTableView.swift
+++ b/ItsME/Presentation/Scenes/EditProfile/OtherItem/CommonView/TableView/UserInfoItemInputTableView.swift
@@ -11,6 +11,11 @@ import UIKit
 
 final class UserInfoItemInputTableView: IntrinsicHeightTableView {
     
+    lazy var inputCells: [UITableViewCell] = [
+        IconInputCell.init(style: .default, reuseIdentifier: IconInputCell.reuseIdentifier),
+        ContentsInputCell.init(style: .default, reuseIdentifier: ContentsInputCell.reuseIdentifier),
+    ]
+    
     override init(frame: CGRect, style: UITableView.Style) {
         super.init(frame: frame, style: style)
         self.register(IconInputCell.self, forCellReuseIdentifier: IconInputCell.reuseIdentifier)
@@ -28,18 +33,10 @@ final class UserInfoItemInputTableView: IntrinsicHeightTableView {
 extension UserInfoItemInputTableView: UITableViewDataSource {
     
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return 2
+        return inputCells.count
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        if indexPath.row == 0 {
-            let cell: IconInputCell = .init(style: .default, reuseIdentifier: IconInputCell.reuseIdentifier)
-            
-            return cell
-        } else {
-            let cell: ContentsInputCell = .init(style: .default, reuseIdentifier: ContentsInputCell.reuseIdentifier)
-            
-            return cell
-        }
+        return inputCells[indexPath.row]
     }
 }

--- a/ItsME/Presentation/Scenes/EditProfile/OtherItem/CommonView/TableView/UserInfoItemInputTableView.swift
+++ b/ItsME/Presentation/Scenes/EditProfile/OtherItem/CommonView/TableView/UserInfoItemInputTableView.swift
@@ -11,10 +11,15 @@ import UIKit
 
 final class UserInfoItemInputTableView: IntrinsicHeightTableView {
     
-    lazy var inputCells: [UITableViewCell] = [
-        IconInputCell.init(style: .default, reuseIdentifier: IconInputCell.reuseIdentifier),
-        ContentsInputCell.init(style: .default, reuseIdentifier: ContentsInputCell.reuseIdentifier),
-    ]
+    lazy var iconInputCell: IconInputCell = .init(style: .default, reuseIdentifier: IconInputCell.reuseIdentifier)
+    lazy var contentsInputCell: ContentsInputCell = .init(style: .default, reuseIdentifier: ContentsInputCell.reuseIdentifier)
+    
+    var inputCells: [UITableViewCell] {
+        [
+            iconInputCell,
+            contentsInputCell,
+        ]
+    }
     
     override init(frame: CGRect, style: UITableView.Style) {
         super.init(frame: frame, style: style)

--- a/ItsME/Presentation/Scenes/EditProfile/OtherItem/CommonView/UserInfoItemInputView.swift
+++ b/ItsME/Presentation/Scenes/EditProfile/OtherItem/CommonView/UserInfoItemInputView.swift
@@ -9,6 +9,7 @@ import SnapKit
 import Then
 import UIKit
 
+/// deprecated
 final class UserInfoItemInputView: UIStackView {
     
     lazy var iconButton: UIButton = .init().then {

--- a/ItsME/Presentation/Scenes/EditProfile/OtherItem/NewOtherItem/NewOtherItemViewController.swift
+++ b/ItsME/Presentation/Scenes/EditProfile/OtherItem/NewOtherItem/NewOtherItemViewController.swift
@@ -58,6 +58,7 @@ private extension NewOtherItemViewController {
     func configureNavigationBar() {
         self.navigationItem.title = "새 항목"
         self.navigationItem.rightBarButtonItem = completeButton
+        self.navigationItem.rightBarButtonItem?.style = .done
     }
     
     func saveUserInfoItem() {

--- a/ItsME/Presentation/Scenes/EditProfile/OtherItem/NewOtherItem/NewOtherItemViewController.swift
+++ b/ItsME/Presentation/Scenes/EditProfile/OtherItem/NewOtherItem/NewOtherItemViewController.swift
@@ -19,15 +19,7 @@ final class NewOtherItemViewController: UIViewController {
         $0.primaryAction = .init(title: "추가", handler: { [weak self] _ in
             guard let self = self else { return }
             self.navigationController?.popViewController(animated: true)
-            
-//            let emojiName = self.userInfoItemInputView.iconButton.titleLabel?.text ?? UserInfoItemIcon.default.toEmoji
-//            let icon: UserInfoItemIcon = .init(rawValue: emojiName) ?? .default
-//            let contents = self.userInfoItemInputView.contentsTextField.text!
-//            let newItem: UserInfoItem = .init(
-//                icon: icon,
-//                contents: contents
-//            )
-//            self.viewModel.appendUserInfoItem(newItem)
+            self.saveUserInfoItem()
         })
     }
     
@@ -66,5 +58,17 @@ private extension NewOtherItemViewController {
     func configureNavigationBar() {
         self.navigationItem.title = "새 항목"
         self.navigationItem.rightBarButtonItem = completeButton
+    }
+    
+    func saveUserInfoItem() {
+        let emojiName = (userInfoItemInputTableView.inputCells[0] as? IconInputCell)?.iconLabel.text ?? UserInfoItemIcon.default.toEmoji
+        let icon: UserInfoItemIcon = .init(rawValue: emojiName) ?? .default
+        let contents = (userInfoItemInputTableView.inputCells[1] as? ContentsInputCell)?.contentsTextField.text ?? ""
+
+        let newItem: UserInfoItem = .init(
+            icon: icon,
+            contents: contents
+        )
+        self.viewModel.appendUserInfoItem(newItem)
     }
 }

--- a/ItsME/Presentation/Scenes/EditProfile/OtherItem/NewOtherItem/NewOtherItemViewController.swift
+++ b/ItsME/Presentation/Scenes/EditProfile/OtherItem/NewOtherItem/NewOtherItemViewController.swift
@@ -61,9 +61,9 @@ private extension NewOtherItemViewController {
     }
     
     func saveUserInfoItem() {
-        let emojiName = (userInfoItemInputTableView.inputCells[0] as? IconInputCell)?.iconLabel.text ?? UserInfoItemIcon.default.toEmoji
-        let icon: UserInfoItemIcon = .init(rawValue: emojiName) ?? .default
-        let contents = (userInfoItemInputTableView.inputCells[1] as? ContentsInputCell)?.contentsTextField.text ?? ""
+        let emoji = userInfoItemInputTableView.iconInputCell.iconLabel.text ?? UserInfoItemIcon.default.toEmoji
+        let icon: UserInfoItemIcon = .init(rawValue: emoji) ?? .default
+        let contents = userInfoItemInputTableView.contentsInputCell.contentsTextField.text ?? ""
 
         let newItem: UserInfoItem = .init(
             icon: icon,

--- a/ItsME/Presentation/Scenes/EditProfile/OtherItem/NewOtherItem/NewOtherItemViewController.swift
+++ b/ItsME/Presentation/Scenes/EditProfile/OtherItem/NewOtherItem/NewOtherItemViewController.swift
@@ -61,14 +61,7 @@ private extension NewOtherItemViewController {
     }
     
     func saveUserInfoItem() {
-        let emoji = userInfoItemInputTableView.iconInputCell.iconLabel.text ?? UserInfoItemIcon.default.toEmoji
-        let icon: UserInfoItemIcon = .init(rawValue: emoji) ?? .default
-        let contents = userInfoItemInputTableView.contentsInputCell.contentsTextField.text ?? ""
-
-        let newItem: UserInfoItem = .init(
-            icon: icon,
-            contents: contents
-        )
+        let newItem = userInfoItemInputTableView.currentInputUserInfoItem
         self.viewModel.appendUserInfoItem(newItem)
     }
 }

--- a/ItsME/Presentation/Scenes/EditProfile/OtherItem/NewOtherItem/NewOtherItemViewController.swift
+++ b/ItsME/Presentation/Scenes/EditProfile/OtherItem/NewOtherItem/NewOtherItemViewController.swift
@@ -13,23 +13,21 @@ final class NewOtherItemViewController: UIViewController {
     
     private let viewModel: EditProfileViewModel
     
-    private lazy var userInfoItemInputView: UserInfoItemInputView = .init().then {
-        $0.contentsTextField.delegate = self
-    }
+    private lazy var userInfoItemInputTableView: UserInfoItemInputTableView = .init(frame: .zero, style: .insetGrouped)
     
     private lazy var completeButton: UIBarButtonItem = .init().then {
         $0.primaryAction = .init(title: "추가", handler: { [weak self] _ in
             guard let self = self else { return }
             self.navigationController?.popViewController(animated: true)
             
-            let emojiName = self.userInfoItemInputView.iconButton.titleLabel?.text ?? UserInfoItemIcon.default.toEmoji
-            let icon: UserInfoItemIcon = .init(rawValue: emojiName) ?? .default
-            let contents = self.userInfoItemInputView.contentsTextField.text!
-            let newItem: UserInfoItem = .init(
-                icon: icon,
-                contents: contents
-            )
-            self.viewModel.appendUserInfoItem(newItem)
+//            let emojiName = self.userInfoItemInputView.iconButton.titleLabel?.text ?? UserInfoItemIcon.default.toEmoji
+//            let icon: UserInfoItemIcon = .init(rawValue: emojiName) ?? .default
+//            let contents = self.userInfoItemInputView.contentsTextField.text!
+//            let newItem: UserInfoItem = .init(
+//                icon: icon,
+//                contents: contents
+//            )
+//            self.viewModel.appendUserInfoItem(newItem)
         })
     }
     
@@ -37,14 +35,9 @@ final class NewOtherItemViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        self.view.backgroundColor = .systemBackground
+        self.view.backgroundColor = .secondarySystemBackground
         configureSubviews()
         configureNavigationBar()
-    }
-    
-    override func viewDidAppear(_ animated: Bool) {
-        super.viewDidAppear(animated)
-        userInfoItemInputView.contentsTextField.becomeFirstResponder()
     }
     
     // MARK: - Initializer
@@ -64,26 +57,14 @@ final class NewOtherItemViewController: UIViewController {
 private extension NewOtherItemViewController {
     
     func configureSubviews() {
-        let safeArea = self.view.safeAreaLayoutGuide
-        
-        self.view.addSubview(userInfoItemInputView)
-        userInfoItemInputView.snp.makeConstraints { make in
-            make.top.equalTo(safeArea).offset(10)
-            make.leading.trailing.equalTo(safeArea).inset(10)
+        self.view.addSubview(userInfoItemInputTableView)
+        userInfoItemInputTableView.snp.makeConstraints { make in
+            make.top.leading.trailing.equalTo(self.view.safeAreaLayoutGuide)
         }
     }
     
     func configureNavigationBar() {
         self.navigationItem.title = "새 항목"
         self.navigationItem.rightBarButtonItem = completeButton
-    }
-}
-
-// MARK: - UITextFieldDelegate
-
-extension NewOtherItemViewController: UITextFieldDelegate {
-    
-    func textFieldShouldReturn(_ textField: UITextField) -> Bool {
-        textField.resignFirstResponder()
     }
 }

--- a/ItsME/Presentation/Scenes/EditProfile/OtherItem/OtherItemEditing/OtherItemEditingViewController.swift
+++ b/ItsME/Presentation/Scenes/EditProfile/OtherItem/OtherItemEditing/OtherItemEditingViewController.swift
@@ -80,7 +80,7 @@ private extension OtherItemEditingViewController {
     }
     
     func configureNavigationBar() {
-        self.navigationItem.title = "항목 수정"
+        self.navigationItem.title = "항목 편집"
         self.navigationItem.rightBarButtonItem = completeButton
     }
 }

--- a/ItsME/Presentation/Scenes/EditProfile/OtherItem/OtherItemEditing/OtherItemEditingViewController.swift
+++ b/ItsME/Presentation/Scenes/EditProfile/OtherItem/OtherItemEditing/OtherItemEditingViewController.swift
@@ -15,26 +15,17 @@ final class OtherItemEditingViewController: UIViewController {
     
     private var indexOfItem: IndexPath.Index
     
-    private lazy var userInfoItemInputView: UserInfoItemInputView = .init().then {
-        $0.contentsTextField.delegate = self
-        let userInfoItem = viewModel.currentOtherItems[ifExists: indexOfItem]
-        $0.iconButton.setTitle(userInfoItem?.icon.toEmoji, for: .normal)
-        $0.contentsTextField.text = userInfoItem?.contents
-    }
+    private lazy var userInfoItemInputTableView: UserInfoItemInputTableView = .init(frame: .zero, style: .insetGrouped)
+        .then {
+            let userInfoItem: UserInfoItem = viewModel.currentOtherItems[ifExists: indexOfItem] ?? .empty
+            $0.bind(userInfoItem: userInfoItem)
+        }
     
     private lazy var completeButton: UIBarButtonItem = .init().then {
         $0.primaryAction = .init(title: "완료", handler: { [weak self] _ in
             guard let self = self else { return }
             self.navigationController?.popViewController(animated: true)
-            
-            let emojiName = self.userInfoItemInputView.iconButton.titleLabel?.text ?? UserInfoItemIcon.default.toEmoji
-            let icon: UserInfoItemIcon = .init(rawValue: emojiName) ?? .default
-            let contents = self.userInfoItemInputView.contentsTextField.text!
-            let item: UserInfoItem = .init(
-                icon: icon,
-                contents: contents
-            )
-            self.viewModel.updateUserInfoItem(item, at: self.indexOfItem)
+            self.updateUserInfoItem()
         })
     }
     
@@ -54,14 +45,9 @@ final class OtherItemEditingViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        self.view.backgroundColor = .systemBackground
+        self.view.backgroundColor = .secondarySystemBackground
         configureSubviews()
         configureNavigationBar()
-    }
-    
-    override func viewDidAppear(_ animated: Bool) {
-        super.viewDidAppear(animated)
-        userInfoItemInputView.contentsTextField.becomeFirstResponder()
     }
 }
 
@@ -70,12 +56,9 @@ final class OtherItemEditingViewController: UIViewController {
 private extension OtherItemEditingViewController {
     
     func configureSubviews() {
-        let safeArea = self.view.safeAreaLayoutGuide
-        
-        self.view.addSubview(userInfoItemInputView)
-        userInfoItemInputView.snp.makeConstraints { make in
-            make.top.equalTo(safeArea).offset(10)
-            make.leading.trailing.equalTo(safeArea).inset(10)
+        self.view.addSubview(userInfoItemInputTableView)
+        userInfoItemInputTableView.snp.makeConstraints { make in
+            make.top.leading.trailing.equalTo(self.view.safeAreaLayoutGuide)
         }
     }
     
@@ -83,13 +66,9 @@ private extension OtherItemEditingViewController {
         self.navigationItem.title = "항목 편집"
         self.navigationItem.rightBarButtonItem = completeButton
     }
-}
-
-// MARK: - UITextFieldDelegate
-
-extension OtherItemEditingViewController: UITextFieldDelegate {
     
-    func textFieldShouldReturn(_ textField: UITextField) -> Bool {
-        textField.resignFirstResponder()
+    func updateUserInfoItem() {
+        let item = userInfoItemInputTableView.currentInputUserInfoItem
+        self.viewModel.updateUserInfoItem(item, at: indexOfItem)
     }
 }

--- a/ItsME/Presentation/Scenes/EditProfile/OtherItem/OtherItemEditing/OtherItemEditingViewController.swift
+++ b/ItsME/Presentation/Scenes/EditProfile/OtherItem/OtherItemEditing/OtherItemEditingViewController.swift
@@ -65,6 +65,7 @@ private extension OtherItemEditingViewController {
     func configureNavigationBar() {
         self.navigationItem.title = "항목 편집"
         self.navigationItem.rightBarButtonItem = completeButton
+        self.navigationItem.rightBarButtonItem?.style = .done
     }
     
     func updateUserInfoItem() {

--- a/ItsME/Utils/Protocols/Reusable.swift
+++ b/ItsME/Utils/Protocols/Reusable.swift
@@ -1,0 +1,18 @@
+//
+//  Reusable.swift
+//  ItsME
+//
+//  Created by Jaewon Yun on 2023/02/14.
+//
+
+import UIKit
+
+protocol Reusable {
+    static var reuseIdentifier: String { get }
+}
+
+extension UITableViewCell: Reusable {
+    static var reuseIdentifier: String {
+        .init(describing: self)
+    }
+}


### PR DESCRIPTION
## 변경점 설명
<!-- 필요 시 작성 -->
- Custom Cell 을 구현할때마다 `reuseIdentifier` 를 따로 지정해줬어야 했는데 Reusable Protocol 을 구현함으로써 자동으로 `reuseIdentifier` 를 가지고 있게 함
- 전체적인 프로필 수정 화면 UI 개선

## 참고 자료
<!-- 필요 시 작성 -->
<!-- 이미지, 링크, 플로우차트 등등 -->
<img width="300" alt="image" src="https://user-images.githubusercontent.com/81426024/218994777-faa30748-c135-40b7-9d13-4fcc9cc730a7.png"><img width="300" alt="image" src="https://user-images.githubusercontent.com/81426024/218994823-f74d6099-3adb-4a40-9da9-85b1611319e1.png"><img width="300" alt="image" src="https://user-images.githubusercontent.com/81426024/218994841-71d7eb69-4a93-438a-a562-24e3540877c4.png">


## PR Checklist
<!-- 만족하는 항목은 [ ] 안에 "x" 를 입력해주세요. (ex: [x]) -->
<!-- 꼭!!! 체크하기 전에 다시 한번 확인해주세요!! -->

- [x] 변경 사항을 적용하고 빌드&테스트 실행을 해봤나요?
<!-- - [ ] [Code Convention](https://il-gob.notion.site/Code-Convention-29ce0d4e48e440b9bc74b1a19c99b57b)을 준수했나요? -->
