### PR TITLE
IconInputCell 에 ViewModel 적용

### DIFF
--- a/ItsME.xcodeproj/project.pbxproj
+++ b/ItsME.xcodeproj/project.pbxproj
@@ -36,6 +36,7 @@
 		DA018811296D1483002C5CB0 /* OtherItemEditingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA018810296D1483002C5CB0 /* OtherItemEditingViewController.swift */; };
 		DA0A88692921245000E9AE43 /* UserRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA0A88682921245000E9AE43 /* UserRepository.swift */; };
 		DA26989C298A4709008A5D30 /* DefaultJsonDecoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA26989B298A4709008A5D30 /* DefaultJsonDecoder.swift */; };
+		DA481D78299E085700C8C734 /* IconInputViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA481D77299E085700C8C734 /* IconInputViewModel.swift */; };
 		DA6BCE5E292F04910059E95D /* DatabaseReferenceManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA6BCE5D292F04910059E95D /* DatabaseReferenceManager.swift */; };
 		DA7201E7292F6A0600A69519 /* DatabaseReference+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA7201E6292F6A0600A69519 /* DatabaseReference+Rx.swift */; };
 		DA7201EA29309B2F00A69519 /* ASAuthorizationControllerDelegateProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA7201E929309B2F00A69519 /* ASAuthorizationControllerDelegateProxy.swift */; };
@@ -130,6 +131,7 @@
 		DA018810296D1483002C5CB0 /* OtherItemEditingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OtherItemEditingViewController.swift; sourceTree = "<group>"; };
 		DA0A88682921245000E9AE43 /* UserRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserRepository.swift; sourceTree = "<group>"; };
 		DA26989B298A4709008A5D30 /* DefaultJsonDecoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultJsonDecoder.swift; sourceTree = "<group>"; };
+		DA481D77299E085700C8C734 /* IconInputViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IconInputViewModel.swift; sourceTree = "<group>"; };
 		DA6BCE5D292F04910059E95D /* DatabaseReferenceManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatabaseReferenceManager.swift; sourceTree = "<group>"; };
 		DA7201E6292F6A0600A69519 /* DatabaseReference+Rx.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DatabaseReference+Rx.swift"; sourceTree = "<group>"; };
 		DA7201E929309B2F00A69519 /* ASAuthorizationControllerDelegateProxy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ASAuthorizationControllerDelegateProxy.swift; sourceTree = "<group>"; };
@@ -429,6 +431,7 @@
 			children = (
 				DAAB20C4299B7A1000D5338D /* IconInputCell.swift */,
 				DAAB20C6299B7A5600D5338D /* ContentsInputCell.swift */,
+				DA481D77299E085700C8C734 /* IconInputViewModel.swift */,
 			);
 			path = Cell;
 			sourceTree = "<group>";
@@ -839,6 +842,7 @@
 				DAFCFB63294A9CD0006B287A /* EducationItem.swift in Sources */,
 				DA7201F22931F21100A69519 /* ResumeCategory.swift in Sources */,
 				DA018809296D146A002C5CB0 /* BirthdayEditingViewController.swift in Sources */,
+				DA481D78299E085700C8C734 /* IconInputViewModel.swift in Sources */,
 				DAAF1BDC299A11F400728376 /* UserInfoItemInputView.swift in Sources */,
 				DAB06A3D291BA5B400E86163 /* HomeViewModel.swift in Sources */,
 				DA7201F82931F8EB00A69519 /* CoverLetter.swift in Sources */,

--- a/ItsME/Entities/UserInfoItem.swift
+++ b/ItsME/Entities/UserInfoItem.swift
@@ -32,6 +32,7 @@ enum UserInfoItemIcon: String {
     case phone = "phone"
     case letter = "letter"
     
+    /// 현재 인스턴스에 할당된 이모지입니다.
     var toEmoji: String {
         switch self {
         case .`default`:

--- a/ItsME/Presentation/Common/TableView/IntrinsicHeightTableView.swift
+++ b/ItsME/Presentation/Common/TableView/IntrinsicHeightTableView.swift
@@ -9,6 +9,16 @@ import UIKit
 
 class IntrinsicHeightTableView: UITableView {
     
+    override init(frame: CGRect, style: UITableView.Style) {
+        super.init(frame: frame, style: style)
+        self.isScrollEnabled = false
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        self.isScrollEnabled = false
+    }
+    
     override var intrinsicContentSize: CGSize {
         return .init(
             width: self.contentSize.width + self.contentInset.left + self.contentInset.right,

--- a/ItsME/Presentation/Scenes/EditProfile/OtherItem/CommonView/Cell/IconInputCell.swift
+++ b/ItsME/Presentation/Scenes/EditProfile/OtherItem/CommonView/Cell/IconInputCell.swift
@@ -31,8 +31,13 @@ final class IconInputCell: UITableViewCell {
     override func setSelected(_ selected: Bool, animated: Bool) {
         super.setSelected(false, animated: false)
     }
+}
+
+// MARK: - Private Functions
+
+private extension IconInputCell {
     
-    private func configureSubviews() {
+    func configureSubviews() {
         self.contentView.addSubview(titleLabel)
         titleLabel.snp.makeConstraints { make in
             make.leading.equalToSuperview().offset(12)

--- a/ItsME/Presentation/Scenes/EditProfile/OtherItem/CommonView/Cell/IconInputCell.swift
+++ b/ItsME/Presentation/Scenes/EditProfile/OtherItem/CommonView/Cell/IconInputCell.swift
@@ -5,23 +5,34 @@
 //  Created by Jaewon Yun on 2023/02/14.
 //
 
+import RxSwift
 import SnapKit
 import Then
 import UIKit
 
 final class IconInputCell: UITableViewCell {
     
+    private let disposeBag: DisposeBag = .init()
+    
+    let viewModel: IconInputViewModel
+    
+    // MARK: - UI Components
+    
     private lazy var titleLabel: UILabel = .init().then {
         $0.text = "아이콘"
     }
     
-    lazy var iconLabel: UILabel = .init().then {
+    private lazy var iconLabel: UILabel = .init().then {
         $0.text = UserInfoItemIcon.default.toEmoji
     }
     
-    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+    // MARK: - Initializer
+    
+    init(style: UITableViewCell.CellStyle, reuseIdentifier: String?, viewModel: IconInputViewModel) {
+        self.viewModel = viewModel
         super.init(style: style, reuseIdentifier: reuseIdentifier)
         configureSubviews()
+        bindViewModel()
     }
     
     required init?(coder: NSCoder) {
@@ -51,5 +62,16 @@ private extension IconInputCell {
             make.top.trailing.bottom.equalToSuperview()
             make.leading.equalTo(titleLabel.snp.trailing).offset(20)
         }
+    }
+    
+    func bindViewModel() {
+        // TODO: 아이콘 변경 이벤트 바인딩
+        let input = IconInputViewModel.Input.init(newIcon: .empty())
+        let output = viewModel.transform(input: input)
+        
+        output.currentIcon
+            .map { $0.toEmoji }
+            .drive(iconLabel.rx.text)
+            .disposed(by: disposeBag)
     }
 }

--- a/ItsME/Presentation/Scenes/EditProfile/OtherItem/CommonView/Cell/IconInputViewModel.swift
+++ b/ItsME/Presentation/Scenes/EditProfile/OtherItem/CommonView/Cell/IconInputViewModel.swift
@@ -1,0 +1,56 @@
+//
+//  IconInputViewModel.swift
+//  ItsME
+//
+//  Created by Jaewon Yun on 2023/02/16.
+//
+
+import RxSwift
+import RxCocoa
+
+/**
+`IconInputCell` 과 바인딩 되는 `ViewModel`
+ 
+ `IconInputCell` 에서 이모지로 변환되어 보여줄 `UserInfoItemIcon` 객체를 `Relay` 로 가지고 있습니다.
+ 
+ 사용자가 아이콘을 선택할 때의 이벤트를 `Input` 으로 받아서 `Relay` 를 업데이트 합니다.
+ */
+final class IconInputViewModel: ViewModelType {
+    
+    struct Input {
+        let newIcon: Driver<UserInfoItemIcon>
+    }
+    
+    struct Output {
+        let currentIcon: Driver<UserInfoItemIcon>
+    }
+    
+    private let disposeBag: DisposeBag = .init()
+    
+    private let iconRelay: BehaviorRelay<UserInfoItemIcon>
+    
+    var currentIcon: UserInfoItemIcon {
+        iconRelay.value
+    }
+    
+    init(icon: UserInfoItemIcon) {
+        self.iconRelay = .init(value: icon)
+    }
+    
+    func transform(input: Input) -> Output {
+        input.newIcon
+            .skip(1)
+            .drive(onNext: updateIcon)
+            .disposed(by: disposeBag)
+        let currentIcon = iconRelay.asDriver()
+        
+        return .init(currentIcon: currentIcon)
+    }
+}
+
+extension IconInputViewModel {
+    
+    func updateIcon(_ icon: UserInfoItemIcon) {
+        iconRelay.accept(icon)
+    }
+}

--- a/ItsME/Presentation/Scenes/EditProfile/OtherItem/CommonView/TableView/UserInfoItemInputTableView.swift
+++ b/ItsME/Presentation/Scenes/EditProfile/OtherItem/CommonView/TableView/UserInfoItemInputTableView.swift
@@ -28,8 +28,8 @@ final class UserInfoItemInputTableView: IntrinsicHeightTableView {
         return .init(icon: icon, contents: contents)
     }
     
-    override init(frame: CGRect, style: UITableView.Style) {
-        super.init(frame: frame, style: style)
+    init(style: UITableView.Style) {
+        super.init(frame: .zero, style: style)
         self.register(IconInputCell.self, forCellReuseIdentifier: IconInputCell.reuseIdentifier)
         self.register(ContentsInputCell.self, forCellReuseIdentifier: ContentsInputCell.reuseIdentifier)
         self.dataSource = self

--- a/ItsME/Presentation/Scenes/EditProfile/OtherItem/CommonView/TableView/UserInfoItemInputTableView.swift
+++ b/ItsME/Presentation/Scenes/EditProfile/OtherItem/CommonView/TableView/UserInfoItemInputTableView.swift
@@ -11,8 +11,15 @@ import UIKit
 
 final class UserInfoItemInputTableView: IntrinsicHeightTableView {
     
-    lazy var iconInputCell: IconInputCell = .init(style: .default, reuseIdentifier: IconInputCell.reuseIdentifier)
-    lazy var contentsInputCell: ContentsInputCell = .init(style: .default, reuseIdentifier: ContentsInputCell.reuseIdentifier)
+    private lazy var iconInputCell: IconInputCell = .init(
+        style: .default,
+        reuseIdentifier: IconInputCell.reuseIdentifier,
+        viewModel: .init(icon: .default)
+    )
+    private lazy var contentsInputCell: ContentsInputCell = .init(
+        style: .default,
+        reuseIdentifier: ContentsInputCell.reuseIdentifier
+    )
     
     var inputCells: [UITableViewCell] {
         [
@@ -21,11 +28,11 @@ final class UserInfoItemInputTableView: IntrinsicHeightTableView {
         ]
     }
     
-    var currentInputUserInfoItem: UserInfoItem {
-        let emoji = iconInputCell.iconLabel.text ?? UserInfoItemIcon.default.toEmoji
-        let icon: UserInfoItemIcon = .init(rawValue: emoji) ?? .default
-        let contents = contentsInputCell.contentsTextField.text ?? ""
-        return .init(icon: icon, contents: contents)
+    var currentUserInfoItem: UserInfoItem {
+        .init(
+            icon: iconInputCell.viewModel.currentIcon,
+            contents: contentsInputCell.contentsTextField.text ?? ""
+        )
     }
     
     init(style: UITableView.Style) {
@@ -40,7 +47,7 @@ final class UserInfoItemInputTableView: IntrinsicHeightTableView {
     }
     
     func bind(userInfoItem: UserInfoItem) {
-        iconInputCell.iconLabel.text = userInfoItem.icon.toEmoji
+        iconInputCell.viewModel.updateIcon(userInfoItem.icon)
         contentsInputCell.contentsTextField.text = userInfoItem.contents
     }
 }

--- a/ItsME/Presentation/Scenes/EditProfile/OtherItem/NewOtherItem/NewOtherItemViewController.swift
+++ b/ItsME/Presentation/Scenes/EditProfile/OtherItem/NewOtherItem/NewOtherItemViewController.swift
@@ -62,7 +62,7 @@ private extension NewOtherItemViewController {
     }
     
     func saveUserInfoItem() {
-        let newItem = userInfoItemInputTableView.currentInputUserInfoItem
+        let newItem = userInfoItemInputTableView.currentUserInfoItem
         self.viewModel.appendUserInfoItem(newItem)
     }
 }

--- a/ItsME/Presentation/Scenes/EditProfile/OtherItem/NewOtherItem/NewOtherItemViewController.swift
+++ b/ItsME/Presentation/Scenes/EditProfile/OtherItem/NewOtherItem/NewOtherItemViewController.swift
@@ -13,7 +13,7 @@ final class NewOtherItemViewController: UIViewController {
     
     private let viewModel: EditProfileViewModel
     
-    private lazy var userInfoItemInputTableView: UserInfoItemInputTableView = .init(frame: .zero, style: .insetGrouped)
+    private lazy var userInfoItemInputTableView: UserInfoItemInputTableView = .init(style: .insetGrouped)
     
     private lazy var completeButton: UIBarButtonItem = .init().then {
         $0.primaryAction = .init(title: "추가", handler: { [weak self] _ in

--- a/ItsME/Presentation/Scenes/EditProfile/OtherItem/OtherItemEditing/OtherItemEditingViewController.swift
+++ b/ItsME/Presentation/Scenes/EditProfile/OtherItem/OtherItemEditing/OtherItemEditingViewController.swift
@@ -15,7 +15,7 @@ final class OtherItemEditingViewController: UIViewController {
     
     private var indexOfItem: IndexPath.Index
     
-    private lazy var userInfoItemInputTableView: UserInfoItemInputTableView = .init(frame: .zero, style: .insetGrouped)
+    private lazy var userInfoItemInputTableView: UserInfoItemInputTableView = .init(style: .insetGrouped)
         .then {
             let userInfoItem: UserInfoItem = viewModel.currentOtherItems[ifExists: indexOfItem] ?? .empty
             $0.bind(userInfoItem: userInfoItem)

--- a/ItsME/Presentation/Scenes/EditProfile/OtherItem/OtherItemEditing/OtherItemEditingViewController.swift
+++ b/ItsME/Presentation/Scenes/EditProfile/OtherItem/OtherItemEditing/OtherItemEditingViewController.swift
@@ -69,7 +69,7 @@ private extension OtherItemEditingViewController {
     }
     
     func updateUserInfoItem() {
-        let item = userInfoItemInputTableView.currentInputUserInfoItem
+        let item = userInfoItemInputTableView.currentUserInfoItem
         self.viewModel.updateUserInfoItem(item, at: indexOfItem)
     }
 }


### PR DESCRIPTION
## 변경점 설명
<!-- 필요 시 작성 -->
- 이해를 돕기 위한 문서화 주석 추가
- 코드 리팩토링
  - 생성자에서 불필요한 파라미터를 지워 코드 간소화
  - private functions 분리
- IconInputCell 에 ViewModel 적용
  - 아이콘 레이블에 직접 접근해서 이모지를 가져오는것보다 ViewModel 을 두고 운영하는게 적절할 것 같다고 판단(후에 아이콘 변경 기능도 추가해야 하므로)
- `IntrinsicHeightTableView` 클래스 개선
  - 스크롤이 필요없기 때문에 enable스크롤 프로퍼티를 false 로 기본 설정


## 참고 자료
<!-- 필요 시 작성 -->
<!-- 이미지, 링크, 플로우차트 등등 -->


## PR Checklist
<!-- 만족하는 항목은 [ ] 안에 "x" 를 입력해주세요. (ex: [x]) -->
<!-- 꼭!!! 체크하기 전에 다시 한번 확인해주세요!! -->

- [x] 변경 사항을 적용하고 빌드&테스트 실행을 해봤나요?
<!-- - [ ] [Code Convention](https://il-gob.notion.site/Code-Convention-29ce0d4e48e440b9bc74b1a19c99b57b)을 준수했나요? -->
