### PR TITLE
:lipstick: :zap: :fire: 프로필 수정 화면 UI 개선

### DIFF
--- a/ItsME.xcodeproj/project.pbxproj
+++ b/ItsME.xcodeproj/project.pbxproj
@@ -37,6 +37,7 @@
 		DA0A88692921245000E9AE43 /* UserRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA0A88682921245000E9AE43 /* UserRepository.swift */; };
 		DA26989C298A4709008A5D30 /* DefaultJsonDecoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA26989B298A4709008A5D30 /* DefaultJsonDecoder.swift */; };
 		DA481D78299E085700C8C734 /* IconInputViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA481D77299E085700C8C734 /* IconInputViewModel.swift */; };
+		DA481D7F299F5DAD00C8C734 /* EditProfileViewController+HeaderLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA481D7E299F5DAD00C8C734 /* EditProfileViewController+HeaderLabel.swift */; };
 		DA6BCE5E292F04910059E95D /* DatabaseReferenceManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA6BCE5D292F04910059E95D /* DatabaseReferenceManager.swift */; };
 		DA7201E7292F6A0600A69519 /* DatabaseReference+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA7201E6292F6A0600A69519 /* DatabaseReference+Rx.swift */; };
 		DA7201EA29309B2F00A69519 /* ASAuthorizationControllerDelegateProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA7201E929309B2F00A69519 /* ASAuthorizationControllerDelegateProxy.swift */; };
@@ -132,6 +133,7 @@
 		DA0A88682921245000E9AE43 /* UserRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserRepository.swift; sourceTree = "<group>"; };
 		DA26989B298A4709008A5D30 /* DefaultJsonDecoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultJsonDecoder.swift; sourceTree = "<group>"; };
 		DA481D77299E085700C8C734 /* IconInputViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IconInputViewModel.swift; sourceTree = "<group>"; };
+		DA481D7E299F5DAD00C8C734 /* EditProfileViewController+HeaderLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "EditProfileViewController+HeaderLabel.swift"; sourceTree = "<group>"; };
 		DA6BCE5D292F04910059E95D /* DatabaseReferenceManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatabaseReferenceManager.swift; sourceTree = "<group>"; };
 		DA7201E6292F6A0600A69519 /* DatabaseReference+Rx.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DatabaseReference+Rx.swift"; sourceTree = "<group>"; };
 		DA7201E929309B2F00A69519 /* ASAuthorizationControllerDelegateProxy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ASAuthorizationControllerDelegateProxy.swift; sourceTree = "<group>"; };
@@ -366,6 +368,14 @@
 			path = Repositories;
 			sourceTree = "<group>";
 		};
+		DA481D7D299F5D7900C8C734 /* CommonView */ = {
+			isa = PBXGroup;
+			children = (
+				DA481D7E299F5DAD00C8C734 /* EditProfileViewController+HeaderLabel.swift */,
+			);
+			path = CommonView;
+			sourceTree = "<group>";
+		};
 		DA6BCE5F292F04930059E95D /* Firebase */ = {
 			isa = PBXGroup;
 			children = (
@@ -407,6 +417,7 @@
 		DAA5B9632938760900BAB04E /* EditProfile */ = {
 			isa = PBXGroup;
 			children = (
+				DA481D7D299F5D7900C8C734 /* CommonView */,
 				DAA5B9642938825A00BAB04E /* EditProfileViewController.swift */,
 				DAA5B9662938827200BAB04E /* EditProfileViewModel.swift */,
 				DA018803296D0E39002C5CB0 /* BirthdayEditing */,
@@ -845,6 +856,7 @@
 				DA481D78299E085700C8C734 /* IconInputViewModel.swift in Sources */,
 				DAAF1BDC299A11F400728376 /* UserInfoItemInputView.swift in Sources */,
 				DAB06A3D291BA5B400E86163 /* HomeViewModel.swift in Sources */,
+				DA481D7F299F5DAD00C8C734 /* EditProfileViewController+HeaderLabel.swift in Sources */,
 				DA7201F82931F8EB00A69519 /* CoverLetter.swift in Sources */,
 				DA7201F42931F25500A69519 /* CoverLetterItem.swift in Sources */,
 				D04FAF95299CB3F60049DBAA /* CoverLetterCell.swift in Sources */,

--- a/ItsME/Presentation/Common/Component/ProfileInfoComponent.swift
+++ b/ItsME/Presentation/Common/Component/ProfileInfoComponent.swift
@@ -34,27 +34,9 @@ final class ProfileInfoComponent: UIStackView {
         return label
     }()
     
-    /// 안쓰임
-    private lazy var iconTextField: UITextField = {
-        let textField: UITextField = .init()
-        textField.text = userInfoItem.icon.toEmoji
-        textField.font = UIFont.systemFont(ofSize: 20, weight: .bold)
-        textField.textAlignment = .center
-        return textField
-    }()
-    
-    /// 안쓰임
-    private lazy var contentsTextField: UITextField = {
-        let textField: UITextField = .init()
-        textField.text = userInfoItem.contents
-        textField.font = UIFont.systemFont(ofSize: 15, weight: .medium)
-        textField.textAlignment = .left
-        return textField
-    }()
-    
     // MARK: - Initialization
     
-    init(userInfoItem: UserInfoItem, isEditingMode: Bool = false) {
+    init(userInfoItem: UserInfoItem) {
         self.userInfoItem = userInfoItem
         super.init(frame: .zero)
         
@@ -63,37 +45,23 @@ final class ProfileInfoComponent: UIStackView {
         self.alignment = .center
         self.distribution = .fill
         
-        configureSubviews(isEditingMode: isEditingMode)
+        configureSubviews()
     }
     
     required init(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
     
-    private func configureSubviews(isEditingMode: Bool) {
-        if isEditingMode {
-            self.addArrangedSubview(iconTextField)
-            self.addArrangedSubview(contentsTextField)
-            
-            iconTextField.snp.makeConstraints { make in
-                make.height.equalToSuperview().multipliedBy(0.9)
-                make.width.equalTo(self.snp.height)
-            }
-            
-            contentsTextField.snp.makeConstraints { make in
-                make.height.equalToSuperview().multipliedBy(0.9)
-            }
-        } else {
-            self.addArrangedSubview(icon)
-            self.addArrangedSubview(contents)
-            
-            icon.snp.makeConstraints { make in
-                make.height.width.equalTo(35)
-            }
-            
-            contents.snp.makeConstraints { make in
-                make.height.equalToSuperview()
-            }
+    private func configureSubviews() {
+        self.addArrangedSubview(icon)
+        self.addArrangedSubview(contents)
+        
+        icon.snp.makeConstraints { make in
+            make.height.width.equalTo(35)
+        }
+        
+        contents.snp.makeConstraints { make in
+            make.height.equalToSuperview()
         }
     }
 }

--- a/ItsME/Presentation/Common/TableView/IntrinsicHeightTableView.swift
+++ b/ItsME/Presentation/Common/TableView/IntrinsicHeightTableView.swift
@@ -14,6 +14,10 @@ class IntrinsicHeightTableView: UITableView {
         self.isScrollEnabled = false
     }
     
+    convenience init(style: UITableView.Style) {
+        self.init(frame: .zero, style: style)
+    }
+    
     required init?(coder: NSCoder) {
         super.init(coder: coder)
         self.isScrollEnabled = false

--- a/ItsME/Presentation/Scenes/EditProfile/CommonView/EditProfileViewController+HeaderLabel.swift
+++ b/ItsME/Presentation/Scenes/EditProfile/CommonView/EditProfileViewController+HeaderLabel.swift
@@ -1,0 +1,26 @@
+//
+//  EditProfileViewController+HeaderLabel.swift
+//  ItsME
+//
+//  Created by Jaewon Yun on 2023/02/17.
+//
+
+import UIKit
+
+extension EditProfileViewController {
+    
+    final class HeaderLabel: UILabel {
+        
+        init(title: String) {
+            super.init(frame: .zero)
+            
+            self.text = title
+            self.font = .boldSystemFont(ofSize: 26)
+            self.textColor = .systemBlue
+        }
+        
+        required init?(coder: NSCoder) {
+            fatalError("init(coder:) has not been implemented")
+        }
+    }
+}

--- a/ItsME/Presentation/Scenes/EditProfile/EditProfileViewController.swift
+++ b/ItsME/Presentation/Scenes/EditProfile/EditProfileViewController.swift
@@ -43,6 +43,7 @@ final class EditProfileViewController: UIViewController {
         }
         $0.addAction(action, for: .touchUpInside)
         $0.setTitle("프로필 사진 변경하기", for: .normal)
+        $0.configuration = .borderless()
     }
     
     private lazy var nameTextField: UITextField = .init().then {

--- a/ItsME/Presentation/Scenes/EditProfile/EditProfileViewController.swift
+++ b/ItsME/Presentation/Scenes/EditProfile/EditProfileViewController.swift
@@ -55,6 +55,8 @@ final class EditProfileViewController: UIViewController {
         $0.autocorrectionType = .no
     }
     
+    private lazy var totalUserInfoItemHeaderLabel: HeaderLabel = .init(title: "기본정보")
+    
     private lazy var totalUserInfoItemStackView: UserInfoItemStackView = .init().then {
         $0.hasSeparator = true
         $0.backgroundColor = .systemBackground
@@ -69,11 +71,7 @@ final class EditProfileViewController: UIViewController {
         $0.addAction(action, for: .touchUpInside)
     }
     
-    private lazy var educationHeaderLabel: UILabel = .init().then {
-        $0.text = "학력"
-        $0.font = .boldSystemFont(ofSize: 26)
-        $0.textColor = .systemBlue
-    }
+    private lazy var educationHeaderLabel: HeaderLabel = .init(title: "학력")
     
     private lazy var educationTableView: IntrinsicHeightTableView = .init(frame: .zero, style: .insetGrouped).then {
         $0.delegate = self
@@ -169,6 +167,8 @@ private extension EditProfileViewController {
 private extension EditProfileViewController {
     
     func configureSubviews() {
+        let headerHorizontalInsetValue = 26
+        
         self.view.addSubview(containerScrollView)
         containerScrollView.snp.makeConstraints { make in
             make.edges.equalToSuperview()
@@ -198,9 +198,15 @@ private extension EditProfileViewController {
             make.leading.trailing.equalToSuperview().inset(30)
         }
         
+        self.contentView.addSubview(totalUserInfoItemHeaderLabel)
+        totalUserInfoItemHeaderLabel.snp.makeConstraints { make in
+            make.top.equalTo(nameTextField.snp.bottom).offset(25)
+            make.leading.trailing.equalToSuperview().inset(headerHorizontalInsetValue)
+        }
+        
         self.contentView.addSubview(totalUserInfoItemStackView)
         totalUserInfoItemStackView.snp.makeConstraints { make in
-            make.top.equalTo(nameTextField.snp.bottom).offset(25)
+            make.top.equalTo(totalUserInfoItemHeaderLabel.snp.bottom).offset(10)
             make.left.right.equalToSuperview().inset(20)
         }
         
@@ -214,7 +220,7 @@ private extension EditProfileViewController {
         
         self.contentView.addSubview(educationHeaderLabel)
         educationHeaderLabel.snp.makeConstraints { make in
-            make.left.right.equalToSuperview().inset(26)
+            make.leading.trailing.equalToSuperview().inset(headerHorizontalInsetValue)
             make.top.equalTo(userInfoItemAddButton.snp.bottom).offset(20)
         }
         

--- a/ItsME/Presentation/Scenes/EditProfile/EditProfileViewController.swift
+++ b/ItsME/Presentation/Scenes/EditProfile/EditProfileViewController.swift
@@ -83,7 +83,9 @@ final class EditProfileViewController: UIViewController {
     
     private lazy var educationItemAddButton: ItemAddButton = .init()
     
-    private lazy var editingCompleteButton: UIBarButtonItem = .init(title: "수정완료")
+    private lazy var editingCompleteButton: UIBarButtonItem = .init(title: "수정완료").then {
+        $0.style = .done
+    }
     
     // MARK: - Initializer
     


### PR DESCRIPTION
## 변경점 설명
<!-- 필요 시 작성 -->
#### UI
- 기본정보 헤더 라벨 추가
- 수정 완료 버튼에 bold 처리
- 프로필 사진 변경하기 문구 사이즈 적절하게 조정

#### 개선
- `IntrinsicHeightTableView`에 convenience initializer 추가
- `ProfileInfoComponent`에서 안쓰이던 코드 삭제(UITextField 관련)

## 참고 자료
<!-- 필요 시 작성 -->
<!-- 이미지, 링크, 플로우차트 등등 -->
<img width="350" alt="image" src="https://user-images.githubusercontent.com/81426024/220042319-f09a9b2d-fe3d-4d5f-bae7-7645e1b5c268.png">



## PR Checklist
<!-- 만족하는 항목은 [ ] 안에 "x" 를 입력해주세요. (ex: [x]) -->
<!-- 꼭!!! 체크하기 전에 다시 한번 확인해주세요!! -->

- [x] 변경 사항을 적용하고 빌드&테스트 실행을 해봤나요?
<!-- - [ ] [Code Convention](https://il-gob.notion.site/Code-Convention-29ce0d4e48e440b9bc74b1a19c99b57b)을 준수했나요? -->
