### PR TITLE
:zap: 프로필 수정 화면 구현 방법 변경

### DIFF
--- a/ItsME.xcodeproj/project.pbxproj
+++ b/ItsME.xcodeproj/project.pbxproj
@@ -38,6 +38,7 @@
 		DA26989C298A4709008A5D30 /* DefaultJsonDecoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA26989B298A4709008A5D30 /* DefaultJsonDecoder.swift */; };
 		DA481D78299E085700C8C734 /* IconInputViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA481D77299E085700C8C734 /* IconInputViewModel.swift */; };
 		DA481D7F299F5DAD00C8C734 /* EditProfileViewController+HeaderLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA481D7E299F5DAD00C8C734 /* EditProfileViewController+HeaderLabel.swift */; };
+		DA481D87299F735E00C8C734 /* UserInfoItemCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA481D86299F735E00C8C734 /* UserInfoItemCell.swift */; };
 		DA6BCE5E292F04910059E95D /* DatabaseReferenceManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA6BCE5D292F04910059E95D /* DatabaseReferenceManager.swift */; };
 		DA7201E7292F6A0600A69519 /* DatabaseReference+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA7201E6292F6A0600A69519 /* DatabaseReference+Rx.swift */; };
 		DA7201EA29309B2F00A69519 /* ASAuthorizationControllerDelegateProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA7201E929309B2F00A69519 /* ASAuthorizationControllerDelegateProxy.swift */; };
@@ -134,6 +135,7 @@
 		DA26989B298A4709008A5D30 /* DefaultJsonDecoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultJsonDecoder.swift; sourceTree = "<group>"; };
 		DA481D77299E085700C8C734 /* IconInputViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IconInputViewModel.swift; sourceTree = "<group>"; };
 		DA481D7E299F5DAD00C8C734 /* EditProfileViewController+HeaderLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "EditProfileViewController+HeaderLabel.swift"; sourceTree = "<group>"; };
+		DA481D86299F735E00C8C734 /* UserInfoItemCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserInfoItemCell.swift; sourceTree = "<group>"; };
 		DA6BCE5D292F04910059E95D /* DatabaseReferenceManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatabaseReferenceManager.swift; sourceTree = "<group>"; };
 		DA7201E6292F6A0600A69519 /* DatabaseReference+Rx.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DatabaseReference+Rx.swift"; sourceTree = "<group>"; };
 		DA7201E929309B2F00A69519 /* ASAuthorizationControllerDelegateProxy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ASAuthorizationControllerDelegateProxy.swift; sourceTree = "<group>"; };
@@ -372,6 +374,7 @@
 			isa = PBXGroup;
 			children = (
 				DA481D7E299F5DAD00C8C734 /* EditProfileViewController+HeaderLabel.swift */,
+				DA481D86299F735E00C8C734 /* UserInfoItemCell.swift */,
 			);
 			path = CommonView;
 			sourceTree = "<group>";
@@ -832,6 +835,7 @@
 				DA7201F02931EEE600A69519 /* CVInfo.swift in Sources */,
 				DAB06A40291BA61100E86163 /* ViewModelType.swift in Sources */,
 				DAAC7A5C29715C0A0083A8E9 /* Rx+Ext.swift in Sources */,
+				DA481D87299F735E00C8C734 /* UserInfoItemCell.swift in Sources */,
 				DAFCFB67294AC00C006B287A /* UIStackView+.swift in Sources */,
 				DA7201FA2931F90900A69519 /* Resume.swift in Sources */,
 				DAAB20BF299B682900D5338D /* UserInfoItemInputTableView.swift in Sources */,

--- a/ItsME/Entities/UserInfo.swift
+++ b/ItsME/Entities/UserInfo.swift
@@ -21,6 +21,10 @@ final class UserInfo: Decodable {
         [birthday, address, phoneNumber, email]
     }
     
+    var allItems: [UserInfoItem] {
+        defaultItems + otherItems
+    }
+    
     init(
         name: String,
         profileImageURL: String,

--- a/ItsME/Presentation/Common/Component/ProfileInfoComponent.swift
+++ b/ItsME/Presentation/Common/Component/ProfileInfoComponent.swift
@@ -11,7 +11,17 @@ import SnapKit
 
 final class ProfileInfoComponent: UIStackView {
     
-    var userInfoItem: UserInfoItem
+    /**
+     `ProfileInfoComponent` 가 현재 보여주고 있는 `UserInfoItem` 객체입니다.
+     
+     Component 의 내용을 변경하고 싶다면 이 프로퍼티에 새 객체를 할당하십시오.
+     */
+    var userInfoItem: UserInfoItem {
+        didSet {
+            icon.text = userInfoItem.icon.toEmoji
+            contents.text = userInfoItem.contents
+        }
+    }
     
     // MARK: - UI Components
     

--- a/ItsME/Presentation/Scenes/EditProfile/CommonView/UserInfoItemCell.swift
+++ b/ItsME/Presentation/Scenes/EditProfile/CommonView/UserInfoItemCell.swift
@@ -1,0 +1,40 @@
+//
+//  UserInfoItemCell.swift
+//  ItsME
+//
+//  Created by Jaewon Yun on 2023/02/17.
+//
+
+import SnapKit
+import UIKit
+
+final class UserInfoItemCell: UITableViewCell {
+    
+    private lazy var profileInfoComponent: ProfileInfoComponent = .init(userInfoItem: .empty)
+    
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        self.backgroundColor = .systemBackground
+        configureSubviews()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    func bind(userInfoItem: UserInfoItem) {
+        profileInfoComponent.userInfoItem = userInfoItem
+    }
+}
+
+// MARK: - Private Functions
+
+private extension UserInfoItemCell {
+    
+    func configureSubviews() {
+        self.contentView.addSubview(profileInfoComponent)
+        profileInfoComponent.snp.makeConstraints { make in
+            make.edges.equalToSuperview().inset(4)
+        }
+    }
+}

--- a/ItsME/Presentation/Scenes/EditProfile/EditProfileViewController.swift
+++ b/ItsME/Presentation/Scenes/EditProfile/EditProfileViewController.swift
@@ -287,6 +287,23 @@ private extension EditProfileViewController {
         let viewController: NewOtherItemViewController = .init(viewModel: viewModel)
         self.navigationController?.pushViewController(viewController, animated: true)
     }
+    
+    func presentUserInfoItemInputView(by indexPath: IndexPath) {
+        switch viewModel.currentAllItems[ifExists: indexPath.row]?.icon {
+        case .cake:
+            presentDatePickerView()
+        case .house:
+            presentAddressEditingView()
+        case .phone:
+            presentPhoneNumberEditingView()
+        case .letter:
+            presentEmailEditingView()
+        default:
+            if let otherItem = viewModel.currentAllItems[ifExists: indexPath.row] {
+                presentOtherItemEditingView(with: otherItem)
+            }
+        }
+    }
 }
 
 // MARK: - UITableViewDelegate
@@ -311,20 +328,7 @@ extension EditProfileViewController: UITableViewDelegate {
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         switch tableView {
         case userInfoItemTableView:
-            switch viewModel.currentAllItems[ifExists: indexPath.row]?.icon {
-            case .cake:
-                presentDatePickerView()
-            case .house:
-                presentAddressEditingView()
-            case .phone:
-                presentPhoneNumberEditingView()
-            case .letter:
-                presentEmailEditingView()
-            default:
-                if let otherItem = viewModel.currentAllItems[ifExists: indexPath.row] {
-                    presentOtherItemEditingView(with: otherItem)
-                }
-            }
+            presentUserInfoItemInputView(by: indexPath)
         case educationTableView:
             return
         default:

--- a/ItsME/Presentation/Scenes/EditProfile/EditProfileViewModel.swift
+++ b/ItsME/Presentation/Scenes/EditProfile/EditProfileViewModel.swift
@@ -41,6 +41,10 @@ final class EditProfileViewModel: ViewModelType {
         userInfoRelay.value.otherItems
     }
     
+    var currentAllItems: [UserInfoItem] {
+        userInfoRelay.value.allItems
+    }
+    
     init(userInfo: UserInfo) {
         self.userInfoRelay = .init(value: userInfo)
     }
@@ -64,7 +68,7 @@ final class EditProfileViewModel: ViewModelType {
             .do(onNext: { userName in
                 self.userInfoRelay.value.name = userName
             })
-        let userInfoItems = userInfoDriver.map { $0.defaultItems + $0.otherItems }
+        let userInfoItems = userInfoDriver.map { $0.allItems }
         let educationItems = userInfoDriver.map { $0.educationItems }
         let tappedEditingCompleteButton = input.tapEditingCompleteButton
             .withLatestFrom(userInfoDriver)

--- a/ItsME/Presentation/Scenes/EditProfile/EditProfileViewModel.swift
+++ b/ItsME/Presentation/Scenes/EditProfile/EditProfileViewModel.swift
@@ -109,7 +109,7 @@ extension EditProfileViewModel {
         userInfoRelay.accept(userInfo)
     }
     
-    func updateUserInfoItem(_ userInfoItem: UserInfoItem, at index: IndexPath.Index) {
+    func updateOtherUserInfoItem(_ userInfoItem: UserInfoItem, at index: IndexPath.Index) {
         let userInfo = userInfoRelay.value
         if userInfo.otherItems.indices ~= index {
             userInfo.otherItems[index] = userInfoItem

--- a/ItsME/Presentation/Scenes/EditProfile/OtherItem/OtherItemEditing/OtherItemEditingViewController.swift
+++ b/ItsME/Presentation/Scenes/EditProfile/OtherItem/OtherItemEditing/OtherItemEditingViewController.swift
@@ -70,6 +70,6 @@ private extension OtherItemEditingViewController {
     
     func updateUserInfoItem() {
         let item = userInfoItemInputTableView.currentUserInfoItem
-        self.viewModel.updateUserInfoItem(item, at: indexOfItem)
+        self.viewModel.updateOtherUserInfoItem(item, at: indexOfItem)
     }
 }


### PR DESCRIPTION
## 변경점 설명
<!-- 필요 시 작성 -->
#### 주요 변경점
- 프로필 수정 화면의 기본정보 View: StackView 에서 TableView 사용으로 구현 방법 변경
  - 해당 TableView 에서 사용할 Cell 정의

#### 개선
- 함수 관련 리팩토링
- 편의성을 위한 Computed property 정의
- `ProfileInfoComponent`가 가지고 있는 UserInfoItem 프로퍼티에 명확한 의미 부여

## 참고 자료
<!-- 필요 시 작성 -->
<!-- 이미지, 링크, 플로우차트 등등 -->
<img width="400" alt="image" src="https://user-images.githubusercontent.com/81426024/220054883-2fcffe22-e409-4e38-94ce-c5798f7eacf4.png">


## PR Checklist
<!-- 만족하는 항목은 [ ] 안에 "x" 를 입력해주세요. (ex: [x]) -->
<!-- 꼭!!! 체크하기 전에 다시 한번 확인해주세요!! -->

- [x] 변경 사항을 적용하고 빌드&테스트 실행을 해봤나요?
<!-- - [ ] [Code Convention](https://il-gob.notion.site/Code-Convention-29ce0d4e48e440b9bc74b1a19c99b57b)을 준수했나요? -->
