### PR TITLE
프로필 수정 화면에서의 사용자 사용성 개선

### DIFF
--- a/ItsME.xcodeproj/project.pbxproj
+++ b/ItsME.xcodeproj/project.pbxproj
@@ -67,6 +67,7 @@
 		DAAFB2532918EE5A007A8DF0 /* UserInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAAFB2522918EE5A007A8DF0 /* UserInfo.swift */; };
 		DAB06A3D291BA5B400E86163 /* HomeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAB06A3C291BA5B400E86163 /* HomeViewModel.swift */; };
 		DAB06A40291BA61100E86163 /* ViewModelType.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAB06A3F291BA61100E86163 /* ViewModelType.swift */; };
+		DADDEEA629A8AD9A00D31B02 /* InsetTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = DADDEEA529A8AD9A00D31B02 /* InsetTextField.swift */; };
 		DAE6090B2942095400481742 /* TotalUserInfoItemStackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAE6090A2942095400481742 /* TotalUserInfoItemStackView.swift */; };
 		DAE6090D29420D9900481742 /* ItemAddButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAE6090C29420D9900481742 /* ItemAddButton.swift */; };
 		DAFCFB63294A9CD0006B287A /* EducationItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAFCFB62294A9CD0006B287A /* EducationItem.swift */; };
@@ -166,6 +167,7 @@
 		DAAFB2522918EE5A007A8DF0 /* UserInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserInfo.swift; sourceTree = "<group>"; };
 		DAB06A3C291BA5B400E86163 /* HomeViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewModel.swift; sourceTree = "<group>"; };
 		DAB06A3F291BA61100E86163 /* ViewModelType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewModelType.swift; sourceTree = "<group>"; };
+		DADDEEA529A8AD9A00D31B02 /* InsetTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InsetTextField.swift; sourceTree = "<group>"; };
 		DAE6090A2942095400481742 /* TotalUserInfoItemStackView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TotalUserInfoItemStackView.swift; sourceTree = "<group>"; };
 		DAE6090C29420D9900481742 /* ItemAddButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItemAddButton.swift; sourceTree = "<group>"; };
 		DAFCFB62294A9CD0006B287A /* EducationItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EducationItem.swift; sourceTree = "<group>"; };
@@ -302,6 +304,7 @@
 		D0CCF4E429260AF300AD4AE6 /* Common */ = {
 			isa = PBXGroup;
 			children = (
+				DADDEEA729A8B3D100D31B02 /* TextField */,
 				DA481D8A29A4BFF100C8C734 /* TextView */,
 				D06CD86929936B36005DFB3B /* TableSection */,
 				DAFCFB6D295068EE006B287A /* TableView */,
@@ -575,6 +578,14 @@
 			path = Protocols;
 			sourceTree = "<group>";
 		};
+		DADDEEA729A8B3D100D31B02 /* TextField */ = {
+			isa = PBXGroup;
+			children = (
+				DADDEEA529A8AD9A00D31B02 /* InsetTextField.swift */,
+			);
+			path = TextField;
+			sourceTree = "<group>";
+		};
 		DAFCFB6A294C3622006B287A /* Cells */ = {
 			isa = PBXGroup;
 			children = (
@@ -844,6 +855,7 @@
 				DA7201EC29309B9600A69519 /* AuthenticationServices+Rx.swift in Sources */,
 				D09AC9792918DE8B0081C0EC /* HomeViewController.swift in Sources */,
 				DA7201F02931EEE600A69519 /* CVInfo.swift in Sources */,
+				DADDEEA629A8AD9A00D31B02 /* InsetTextField.swift in Sources */,
 				DAB06A40291BA61100E86163 /* ViewModelType.swift in Sources */,
 				DAAC7A5C29715C0A0083A8E9 /* Rx+Ext.swift in Sources */,
 				DA481D87299F735E00C8C734 /* UserInfoItemCell.swift in Sources */,

--- a/ItsME.xcodeproj/project.pbxproj
+++ b/ItsME.xcodeproj/project.pbxproj
@@ -431,9 +431,9 @@
 		DAA5B9632938760900BAB04E /* ProfileEditing */ = {
 			isa = PBXGroup;
 			children = (
-				DA481D7D299F5D7900C8C734 /* CommonView */,
 				DAA5B9642938825A00BAB04E /* ProfileEditingViewController.swift */,
 				DAA5B9662938827200BAB04E /* ProfileEditingViewModel.swift */,
+				DA481D7D299F5D7900C8C734 /* CommonView */,
 				DA018803296D0E39002C5CB0 /* BirthdayEditing */,
 				DA018804296D10B5002C5CB0 /* AddressEditing */,
 				DA018805296D10BD002C5CB0 /* PhoneNumberEditing */,

--- a/ItsME/Presentation/Common/Component/ItemAddButton.swift
+++ b/ItsME/Presentation/Common/Component/ItemAddButton.swift
@@ -42,7 +42,7 @@ final class ItemAddButton: UIButton {
 private extension ItemAddButton {
     
     func configureColor() {
-        setBackgroundColor(.systemBackground, for: .normal)
+        setBackgroundColor(.secondarySystemGroupedBackground, for: .normal)
         setBackgroundColor(.systemGray4, for: .highlighted)
         self.tintColor = mainColor
     }

--- a/ItsME/Presentation/Common/TextField/InsetTextField.swift
+++ b/ItsME/Presentation/Common/TextField/InsetTextField.swift
@@ -1,0 +1,34 @@
+//
+//  InsetTextField.swift
+//  ItsME
+//
+//  Created by Jaewon Yun on 2023/02/24.
+//
+
+import UIKit
+
+final class InsetTextField: UITextField {
+    
+    let inset: UIEdgeInsets
+    
+    init(frame: CGRect = .zero, inset: UIEdgeInsets = .init(top: 4, left: 10, bottom: 4, right: 10)) {
+        self.inset = inset
+        super.init(frame: frame)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func textRect(forBounds bounds: CGRect) -> CGRect {
+        return bounds.inset(by: inset)
+    }
+    
+    override func editingRect(forBounds bounds: CGRect) -> CGRect {
+        return bounds.inset(by: inset)
+    }
+    
+    override func placeholderRect(forBounds bounds: CGRect) -> CGRect {
+        return bounds.inset(by: inset)
+    }
+}

--- a/ItsME/Presentation/Scenes/ProfileEditing/AddressEditing/AddressEditingViewController.swift
+++ b/ItsME/Presentation/Scenes/ProfileEditing/AddressEditing/AddressEditingViewController.swift
@@ -17,7 +17,7 @@ final class AddressEditingViewController: UIViewController {
     
     private lazy var addressTextView: IntrinsicHeightTextView = .init().then {
         $0.text = viewModel.currentAddress
-        $0.backgroundColor = .systemBackground
+        $0.backgroundColor = .secondarySystemGroupedBackground
         $0.textContainerInset = .init(top: 10, left: 10, bottom: 10, right: 10)
         $0.font = .systemFont(ofSize: 17)
         $0.keyboardType = .twitter
@@ -46,7 +46,7 @@ final class AddressEditingViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        self.view.backgroundColor = .secondarySystemBackground
+        self.view.backgroundColor = .systemGroupedBackground
         configureSubviews()
         configureNavigationBar()
     }

--- a/ItsME/Presentation/Scenes/ProfileEditing/BirthdayEditing/BirthdayEditingViewController.swift
+++ b/ItsME/Presentation/Scenes/ProfileEditing/BirthdayEditing/BirthdayEditingViewController.swift
@@ -20,22 +20,18 @@ final class BirthdayEditingViewController: UIViewController {
         $0.datePickerMode = .date
         $0.date = viewModel.currentBirthday
         $0.backgroundColor = .systemBackground
+        let action: UIAction = .init { [weak self] _ in
+            guard let self = self else { return }
+            self.updateBirthday(by: self.datePickerView.date)
+        }
+        $0.addAction(action, for: .valueChanged)
     }
     
     private lazy var completeButton: UIBarButtonItem = .init().then {
         $0.primaryAction = .init(title: "완료", handler: { [weak self] _ in
             guard let self = self else { return }
             self.dismiss(animated: false)
-            
-            let dateFormatter: DateFormatter = .init().then {
-                $0.dateFormat = "yyyy.MM.dd."
-            }
-            let birthday: String = dateFormatter.string(from: self.datePickerView.date)
-            let newItem: UserInfoItem = .init(
-                icon: .cake,
-                contents: birthday
-            )
-            self.viewModel.updateBirthday(newItem)
+            self.updateBirthday(by: self.datePickerView.date)
         })
     }
     
@@ -105,5 +101,17 @@ private extension BirthdayEditingViewController {
             make.width.equalToSuperview()
             make.bottom.equalTo(datePickerView.snp.top)
         }
+    }
+    
+    func updateBirthday(by date: Date) {
+        let dateFormatter: DateFormatter = .init().then {
+            $0.dateFormat = "yyyy.MM.dd."
+        }
+        let birthday: String = dateFormatter.string(from: date)
+        let newItem: UserInfoItem = .init(
+            icon: .cake,
+            contents: birthday
+        )
+        self.viewModel.updateBirthday(newItem)
     }
 }

--- a/ItsME/Presentation/Scenes/ProfileEditing/CommonView/UserInfoItemCell.swift
+++ b/ItsME/Presentation/Scenes/ProfileEditing/CommonView/UserInfoItemCell.swift
@@ -14,7 +14,7 @@ final class UserInfoItemCell: UITableViewCell {
     
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
-        self.backgroundColor = .systemBackground
+        self.backgroundColor = .secondarySystemGroupedBackground
         configureSubviews()
     }
     

--- a/ItsME/Presentation/Scenes/ProfileEditing/CommonView/UserInfoItemCell.swift
+++ b/ItsME/Presentation/Scenes/ProfileEditing/CommonView/UserInfoItemCell.swift
@@ -6,11 +6,21 @@
 //
 
 import SnapKit
+import Then
 import UIKit
 
 final class UserInfoItemCell: UITableViewCell {
     
-    private lazy var profileInfoComponent: ProfileInfoComponent = .init(userInfoItem: .empty)
+    private lazy var iconLabel: UILabel = .init().then {
+        $0.font = .systemFont(ofSize: 20, weight: .bold)
+        $0.textAlignment = .center
+    }
+    
+    private lazy var contentsLabel: UILabel = .init().then {
+        $0.font = .systemFont(ofSize: 15, weight: .medium)
+        $0.numberOfLines = 0
+        $0.lineBreakMode = .byWordWrapping
+    }
     
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
@@ -23,7 +33,8 @@ final class UserInfoItemCell: UITableViewCell {
     }
     
     func bind(userInfoItem: UserInfoItem) {
-        profileInfoComponent.userInfoItem = userInfoItem
+        iconLabel.text = userInfoItem.icon.toEmoji
+        contentsLabel.text = userInfoItem.contents
     }
 }
 
@@ -32,9 +43,21 @@ final class UserInfoItemCell: UITableViewCell {
 private extension UserInfoItemCell {
     
     func configureSubviews() {
-        self.contentView.addSubview(profileInfoComponent)
-        profileInfoComponent.snp.makeConstraints { make in
-            make.edges.equalToSuperview().inset(4)
+        let commonInsetValue = 4
+        
+        self.contentView.addSubview(iconLabel)
+        iconLabel.snp.makeConstraints { make in
+            make.height.width.equalTo(35)
+            make.top.greaterThanOrEqualToSuperview().inset(commonInsetValue)
+            make.bottom.lessThanOrEqualToSuperview().inset(commonInsetValue)
+            make.centerY.equalToSuperview()
+            make.leading.equalToSuperview().inset(commonInsetValue)
+        }
+        
+        self.contentView.addSubview(contentsLabel)
+        contentsLabel.snp.makeConstraints { make in
+            make.top.trailing.bottom.equalToSuperview().inset(commonInsetValue)
+            make.leading.equalTo(iconLabel.snp.trailing).offset(10)
         }
     }
 }

--- a/ItsME/Presentation/Scenes/ProfileEditing/EmailEditing/EmailEditingViewController.swift
+++ b/ItsME/Presentation/Scenes/ProfileEditing/EmailEditing/EmailEditingViewController.swift
@@ -46,7 +46,7 @@ final class EmailEditingViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        self.view.backgroundColor = .secondarySystemBackground
+        self.view.backgroundColor = .systemGroupedBackground
         configureSubviews()
         configureNavigationBar()
     }

--- a/ItsME/Presentation/Scenes/ProfileEditing/OtherItem/CommonView/Cell/ContentsInputCell.swift
+++ b/ItsME/Presentation/Scenes/ProfileEditing/OtherItem/CommonView/Cell/ContentsInputCell.swift
@@ -27,7 +27,7 @@ final class ContentsInputCell: UITableViewCell {
     
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
-        self.backgroundColor = .systemBackground
+        self.backgroundColor = .secondarySystemGroupedBackground
         configureSubviews()
     }
     

--- a/ItsME/Presentation/Scenes/ProfileEditing/OtherItem/CommonView/Cell/IconInputCell.swift
+++ b/ItsME/Presentation/Scenes/ProfileEditing/OtherItem/CommonView/Cell/IconInputCell.swift
@@ -31,7 +31,7 @@ final class IconInputCell: UITableViewCell {
     init(style: UITableViewCell.CellStyle, reuseIdentifier: String?, viewModel: IconInputViewModel) {
         self.viewModel = viewModel
         super.init(style: style, reuseIdentifier: reuseIdentifier)
-        self.backgroundColor = .systemBackground
+        self.backgroundColor = .secondarySystemGroupedBackground
         configureSubviews()
         bindViewModel()
     }

--- a/ItsME/Presentation/Scenes/ProfileEditing/OtherItem/NewOtherItem/NewOtherItemViewController.swift
+++ b/ItsME/Presentation/Scenes/ProfileEditing/OtherItem/NewOtherItem/NewOtherItemViewController.swift
@@ -29,7 +29,7 @@ final class NewOtherItemViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        self.view.backgroundColor = .secondarySystemBackground
+        self.view.backgroundColor = .systemGroupedBackground
         configureSubviews()
         configureNavigationBar()
     }

--- a/ItsME/Presentation/Scenes/ProfileEditing/OtherItem/OtherItemEditing/OtherItemEditingViewController.swift
+++ b/ItsME/Presentation/Scenes/ProfileEditing/OtherItem/OtherItemEditing/OtherItemEditingViewController.swift
@@ -46,7 +46,7 @@ final class OtherItemEditingViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        self.view.backgroundColor = .secondarySystemBackground
+        self.view.backgroundColor = .systemGroupedBackground
         configureSubviews()
         configureNavigationBar()
     }

--- a/ItsME/Presentation/Scenes/ProfileEditing/PhoneNumberEditing/PhoneNumberEditingViewController.swift
+++ b/ItsME/Presentation/Scenes/ProfileEditing/PhoneNumberEditing/PhoneNumberEditingViewController.swift
@@ -45,7 +45,7 @@ final class PhoneNumberEditingViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        self.view.backgroundColor = .secondarySystemBackground
+        self.view.backgroundColor = .systemGroupedBackground
         configureSubviews()
         configureNavigationBar()
     }

--- a/ItsME/Presentation/Scenes/ProfileEditing/ProfileEditingViewController.swift
+++ b/ItsME/Presentation/Scenes/ProfileEditing/ProfileEditingViewController.swift
@@ -346,6 +346,7 @@ extension ProfileEditingViewController: UITableViewDelegate {
         default:
             return
         }
+        tableView.cellForRow(at: indexPath)?.setSelected(false, animated: true)
     }
 }
 

--- a/ItsME/Presentation/Scenes/ProfileEditing/ProfileEditingViewController.swift
+++ b/ItsME/Presentation/Scenes/ProfileEditing/ProfileEditingViewController.swift
@@ -46,14 +46,18 @@ final class ProfileEditingViewController: UIViewController {
         $0.configuration = .borderless()
     }
     
-    private lazy var nameTextField: UITextField = .init().then {
-        $0.borderStyle = .line
+    private lazy var nameTextField: InsetTextField = .init().then {
         $0.textColor = .label
         $0.font = .systemFont(ofSize: 20)
         $0.textAlignment = .center
         $0.placeholder = "이름"
         $0.keyboardType = .namePhonePad
         $0.autocorrectionType = .no
+        $0.backgroundColor = .systemBackground
+        $0.layer.cornerRadius = 16
+        $0.layer.masksToBounds = true
+        $0.layer.borderColor = UIColor.tertiaryLabel.cgColor
+        $0.layer.borderWidth = 1.0
     }
     
     private lazy var totalUserInfoItemHeaderLabel: HeaderLabel = .init(title: "기본정보")
@@ -208,12 +212,12 @@ private extension ProfileEditingViewController {
         self.contentView.addSubview(nameTextField)
         nameTextField.snp.makeConstraints { make in
             make.top.equalTo(profileEditButton.snp.bottom).offset(20)
-            make.leading.trailing.equalToSuperview().inset(30)
+            make.leading.trailing.equalToSuperview().inset(50)
         }
         
         self.contentView.addSubview(totalUserInfoItemHeaderLabel)
         totalUserInfoItemHeaderLabel.snp.makeConstraints { make in
-            make.top.equalTo(nameTextField.snp.bottom).offset(25)
+            make.top.equalTo(nameTextField.snp.bottom).offset(20)
             make.leading.trailing.equalToSuperview().inset(headerHorizontalInsetValue)
         }
         

--- a/ItsME/Presentation/Scenes/ProfileEditing/ProfileEditingViewController.swift
+++ b/ItsME/Presentation/Scenes/ProfileEditing/ProfileEditingViewController.swift
@@ -53,7 +53,7 @@ final class ProfileEditingViewController: UIViewController {
         $0.placeholder = "이름"
         $0.keyboardType = .namePhonePad
         $0.autocorrectionType = .no
-        $0.backgroundColor = .systemBackground
+        $0.backgroundColor = .secondarySystemGroupedBackground
         $0.layer.cornerRadius = 16
         $0.layer.masksToBounds = true
         $0.layer.borderColor = UIColor.tertiaryLabel.cgColor
@@ -119,7 +119,7 @@ final class ProfileEditingViewController: UIViewController {
         super.viewDidLoad()
         bindViewModel()
         configureSubviews()
-        self.view.backgroundColor = .secondarySystemBackground
+        self.view.backgroundColor = .systemGroupedBackground
     }
     
     override func viewWillAppear(_ animated: Bool) {

--- a/ItsME/Presentation/Scenes/ProfileEditing/ProfileEditingViewController.swift
+++ b/ItsME/Presentation/Scenes/ProfileEditing/ProfileEditingViewController.swift
@@ -64,7 +64,7 @@ final class ProfileEditingViewController: UIViewController {
         $0.backgroundColor = .clear
     }
     
-    private lazy var userInfoItemAddButton: ItemAddButton = .init().then {
+    private lazy var userInfoItemAdditionButton: ItemAddButton = .init().then {
         let action: UIAction = .init(handler: { [weak self] _ in
             self?.presentNewOtherItemView()
         })
@@ -225,11 +225,11 @@ private extension ProfileEditingViewController {
             make.left.right.equalToSuperview()
         }
         
-        let tableViewToAdditionButtonOffset = -25
-        let additionButtonHorizontalInset = 30
+        let tableViewToAdditionButtonOffset = -28
+        let additionButtonHorizontalInset = 20
         
-        self.contentView.addSubview(userInfoItemAddButton)
-        userInfoItemAddButton.snp.makeConstraints { make in
+        self.contentView.addSubview(userInfoItemAdditionButton)
+        userInfoItemAdditionButton.snp.makeConstraints { make in
             make.top.equalTo(userInfoItemTableView.snp.bottom).offset(tableViewToAdditionButtonOffset)
             make.centerX.equalToSuperview()
             make.leading.trailing.equalToSuperview().inset(additionButtonHorizontalInset)
@@ -239,7 +239,7 @@ private extension ProfileEditingViewController {
         self.contentView.addSubview(educationHeaderLabel)
         educationHeaderLabel.snp.makeConstraints { make in
             make.leading.trailing.equalToSuperview().inset(headerHorizontalInsetValue)
-            make.top.equalTo(userInfoItemAddButton.snp.bottom).offset(20)
+            make.top.equalTo(userInfoItemAdditionButton.snp.bottom).offset(20)
         }
         
         self.contentView.addSubview(educationTableView)


### PR DESCRIPTION
## 변경점 설명
<!-- 필요 시 작성 -->
### 사용자 사용성 개선
- [뒤로 버튼을 눌러서 돌아왔을때 셀이 하이라이트 되어있지 않게 구현](https://github.com/ILGOB/It-sME/commit/a0d9f03f0af15a150cb6938ee6655110f82ae41a)
- [DatePicker 값 변경 시 View 에 바로 적용 되는 기능 추가](https://github.com/ILGOB/It-sME/commit/d19dd84acbeab7ff6ad128469fe6e0ed4f559f72)
- [항목 추가 버튼 간격 조절](https://github.com/ILGOB/It-sME/commit/7a0aca5dbac23285df9ff724ab4933e80c3de7a7)
- [이름 입력 칸 UI 개선](https://github.com/ILGOB/It-sME/commit/a4a22a9841170d89cb391fec608c40e7af9e54f8)
- [다크모드 색상 재설정 - 배경과 콘텐츠의 색상 반전](https://github.com/ILGOB/It-sME/commit/815c336b84260e0136b42426ffc3603868646dc2)

### 공통 Component 정의
- [Inset 을 가지고 있는 Custom UITextField 정의](https://github.com/ILGOB/It-sME/commit/7565cfef332e285e1311751a7da2255f2324ee2d)

### 코드 개선
- [Custom Cell 의 ProfileInfoComponent 의존성 제거](https://github.com/ILGOB/It-sME/commit/419760059a5079c21cdecce85b654a533c90eff1)
  - `ProfileInfoComponent`가 변경될때 Cell 은 영향을 받지 않도록

## 참고 자료
<!-- 필요 시 작성 -->
<!-- 이미지, 링크, 플로우차트 등등 -->
<img width="350" alt="image" src="https://user-images.githubusercontent.com/81426024/221757314-26341ea9-94bf-45ac-821d-5fb22c15143c.png">


## PR Checklist
<!-- 만족하는 항목은 [ ] 안에 "x" 를 입력해주세요. (ex: [x]) -->
<!-- 꼭!!! 체크하기 전에 다시 한번 확인해주세요!! -->

- [x] 변경 사항을 적용하고 빌드&테스트 실행을 해봤나요?
<!-- - [ ] [Code Convention](https://il-gob.notion.site/Code-Convention-29ce0d4e48e440b9bc74b1a19c99b57b)을 준수했나요? -->
