### PR TITLE
:sparkles: :construction: (feature/totalCV) 카테고리테이블의 헤더뷰에 기능 추가 #140

### DIFF
--- a/ItsME/Presentation/Common/TableSection/CategoryHeaderView.swift
+++ b/ItsME/Presentation/Common/TableSection/CategoryHeaderView.swift
@@ -11,15 +11,32 @@ import UIKit
 
 class CategoryHeaderView: UITableViewHeaderFooterView {
     
+    var isEditingMode: Bool = false {
+        didSet {
+            setNeedsLayout()
+        }
+    }
+    private let buttonWidth = 35
+    private let buttonHeight = 35
+    private let bottomOffset = -10
+    private let verticalEdgesInset = 7
+    private let horizontalEdgesInset = 10
     static let reuseIdentifier: String = .init(describing: CategoryHeaderView.self)
     
     //MARK: - UI Component
+    lazy var headerContentView = UIView().then {
+        $0.backgroundColor = .systemBackground
+    }
     
-    lazy var titleLabel = UILabel().then {
+    lazy var titleTextField = UITextField().then {
+        $0.isUserInteractionEnabled = false
         $0.text = "제목"
-        $0.numberOfLines = 0
         $0.textColor = .systemBlue
-        $0.font = .systemFont(ofSize: 30, weight: .bold)
+        $0.delegate = self
+    }
+    
+    lazy var addButton = UIButton().then {
+        $0.setImage(.init(systemName: "plus"), for: .normal)
     }
     
     override func awakeFromNib() {
@@ -29,25 +46,97 @@ class CategoryHeaderView: UITableViewHeaderFooterView {
     
     override init(reuseIdentifier: String?) {
         super.init(reuseIdentifier: reuseIdentifier)
-        configureSubviews()
+        self.configureSubviews()
+    }
+    
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        
+        if isEditingMode {
+            headerContentView.layer.borderColor = UIColor.tertiaryLabel.cgColor
+            headerContentView.layer.borderWidth = 2.0
+            headerContentView.layer.cornerRadius = 10
+            headerContentView.layer.masksToBounds = true
+            titleTextField.isUserInteractionEnabled = true
+            titleTextField.font = .systemFont(ofSize: 20, weight: .regular)
+            titleTextField.returnKeyType = .done
+            
+            headerContentView.snp.removeConstraints()
+            headerContentView.snp.makeConstraints() { make in
+                make.bottom.equalToSuperview().offset(bottomOffset)
+                make.top.leading.equalToSuperview()
+            }
+            
+            titleTextField.snp.removeConstraints()
+            titleTextField.snp.makeConstraints { make in
+                make.verticalEdges.equalToSuperview().inset(verticalEdgesInset)
+                make.horizontalEdges.equalToSuperview().inset(horizontalEdgesInset)
+            }
+            
+            self.contentView.addSubview(addButton)
+            addButton.snp.makeConstraints { make in
+                make.leading.equalTo(headerContentView.snp.trailing)
+                make.trailing.equalToSuperview()
+                make.height.equalTo(buttonHeight)
+                make.width.equalTo(buttonWidth)
+            }
+            
+        } else {
+            headerContentView.layer.borderColor = UIColor.clear.cgColor
+            headerContentView.layer.borderWidth = 0
+            headerContentView.layer.masksToBounds = false
+            titleTextField.isUserInteractionEnabled = false
+            titleTextField.clearsOnBeginEditing = false
+            titleTextField.font = .systemFont(ofSize: 30, weight: .bold)
+            
+            addButton.removeFromSuperview()
+            
+            headerContentView.removeFromSuperview()
+            self.contentView.addSubview(headerContentView)
+            headerContentView.snp.makeConstraints { make in
+                make.top.directionalHorizontalEdges.equalToSuperview()
+                make.bottom.equalToSuperview().offset(bottomOffset)
+            }
+            titleTextField.removeFromSuperview()
+            self.headerContentView.addSubview(titleTextField)
+            titleTextField.snp.makeConstraints { make in
+                make.edges.equalToSuperview()
+                make.height.equalTo(40)
+            }
+        }
+        
     }
     
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
     
+    @objc func doneButtonAction() {
+        endEditing(true)
+    }
 }
 
 // MARK: - Private Functions
 private extension CategoryHeaderView {
     
     func configureSubviews() {
+        self.contentView.addSubview(headerContentView)
+        headerContentView.snp.makeConstraints { make in
+            make.top.directionalHorizontalEdges.equalToSuperview()
+            make.bottom.equalToSuperview().offset(bottomOffset)
+        }
         
-        self.contentView.addSubview(titleLabel)
-        titleLabel.snp.makeConstraints { make in
-            make.leading.trailing.top.equalToSuperview()
+        self.headerContentView.addSubview(titleTextField)
+        titleTextField.snp.makeConstraints { make in
+            make.edges.equalToSuperview()
             make.height.equalTo(40)
         }
     }
 }
 
+extension CategoryHeaderView: UITextFieldDelegate {
+    func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+        titleTextField.resignFirstResponder()
+        return true
+    }
+}

--- a/ItsME/Presentation/Common/TableSection/CategoryHeaderView.swift
+++ b/ItsME/Presentation/Common/TableSection/CategoryHeaderView.swift
@@ -26,12 +26,15 @@ class CategoryHeaderView: UITableViewHeaderFooterView {
     //MARK: - UI Component
     lazy var headerContentView = UIView().then {
         $0.backgroundColor = .systemBackground
+        $0.layer.cornerRadius = 10
+        $0.layer.borderWidth = 2.0
     }
     
     lazy var titleTextField = UITextField().then {
         $0.isUserInteractionEnabled = false
         $0.text = "제목"
         $0.textColor = .systemBlue
+        $0.returnKeyType = .done
         $0.delegate = self
     }
     
@@ -54,55 +57,18 @@ class CategoryHeaderView: UITableViewHeaderFooterView {
         
         if isEditingMode {
             headerContentView.layer.borderColor = UIColor.tertiaryLabel.cgColor
-            headerContentView.layer.borderWidth = 2.0
-            headerContentView.layer.cornerRadius = 10
             headerContentView.layer.masksToBounds = true
             titleTextField.isUserInteractionEnabled = true
             titleTextField.font = .systemFont(ofSize: 20, weight: .regular)
-            titleTextField.returnKeyType = .done
-            
-            headerContentView.snp.removeConstraints()
-            headerContentView.snp.makeConstraints() { make in
-                make.bottom.equalToSuperview().offset(bottomOffset)
-                make.top.leading.equalToSuperview()
-            }
-            
-            titleTextField.snp.removeConstraints()
-            titleTextField.snp.makeConstraints { make in
-                make.verticalEdges.equalToSuperview().inset(verticalEdgesInset)
-                make.horizontalEdges.equalToSuperview().inset(horizontalEdgesInset)
-            }
-            
-            self.contentView.addSubview(addButton)
-            addButton.snp.makeConstraints { make in
-                make.leading.equalTo(headerContentView.snp.trailing)
-                make.trailing.equalToSuperview()
-                make.height.equalTo(buttonHeight)
-                make.width.equalTo(buttonWidth)
-            }
-            
+            editMode()
         } else {
             headerContentView.layer.borderColor = UIColor.clear.cgColor
-            headerContentView.layer.borderWidth = 0
             headerContentView.layer.masksToBounds = false
             titleTextField.isUserInteractionEnabled = false
             titleTextField.clearsOnBeginEditing = false
             titleTextField.font = .systemFont(ofSize: 30, weight: .bold)
             
-            addButton.removeFromSuperview()
-            
-            headerContentView.removeFromSuperview()
-            self.contentView.addSubview(headerContentView)
-            headerContentView.snp.makeConstraints { make in
-                make.top.directionalHorizontalEdges.equalToSuperview()
-                make.bottom.equalToSuperview().offset(bottomOffset)
-            }
-            titleTextField.removeFromSuperview()
-            self.headerContentView.addSubview(titleTextField)
-            titleTextField.snp.makeConstraints { make in
-                make.edges.equalToSuperview()
-                make.height.equalTo(40)
-            }
+            viewMode()
         }
         
     }
@@ -132,8 +98,39 @@ private extension CategoryHeaderView {
             make.height.equalTo(40)
         }
     }
+    
+    func editMode() {
+        headerContentView.snp.removeConstraints()
+        headerContentView.snp.makeConstraints() { make in
+            make.bottom.equalToSuperview().offset(bottomOffset)
+            make.top.leading.equalToSuperview()
+        }
+        
+        titleTextField.snp.removeConstraints()
+        titleTextField.snp.makeConstraints { make in
+            make.verticalEdges.equalToSuperview().inset(verticalEdgesInset)
+            make.horizontalEdges.equalToSuperview().inset(horizontalEdgesInset)
+        }
+        
+        self.contentView.addSubview(addButton)
+        addButton.snp.makeConstraints { make in
+            make.leading.equalTo(headerContentView.snp.trailing)
+            make.trailing.equalToSuperview()
+            make.height.equalTo(buttonHeight)
+            make.width.equalTo(buttonWidth)
+        }
+    }
+    
+    func viewMode() {
+        addButton.removeFromSuperview()
+        titleTextField.removeFromSuperview()
+        headerContentView.removeFromSuperview()
+        
+        configureSubviews()
+    }
 }
 
+// MARK: - TextField Delegate
 extension CategoryHeaderView: UITextFieldDelegate {
     func textFieldShouldReturn(_ textField: UITextField) -> Bool {
         titleTextField.resignFirstResponder()

--- a/ItsME/Presentation/Scenes/TotalCV/TotalCVViewController.swift
+++ b/ItsME/Presentation/Scenes/TotalCV/TotalCVViewController.swift
@@ -16,7 +16,7 @@ class TotalCVViewController: UIViewController {
     
     var viewModel: TotalCVViewModel!
     let headerFont: UIFont = .systemFont(ofSize: 30, weight: .bold)
-    var isEditingMode: Bool = false
+    private var isEditingMode: Bool = false
     let navigationBarHeight = 91
     let editModeInset = 15
     let commonOffset = 15
@@ -118,8 +118,6 @@ class TotalCVViewController: UIViewController {
                 }
                 headerView.isEditingMode = self.isEditingMode
             }
-            self.categoryTableView.reloadData() // 변경된 데이터를 다시 로드
-
             self.changeButton()
             self.changeMode()
         })

--- a/ItsME/Presentation/Scenes/TotalCV/TotalCVViewController.swift
+++ b/ItsME/Presentation/Scenes/TotalCV/TotalCVViewController.swift
@@ -16,13 +16,13 @@ class TotalCVViewController: UIViewController {
     
     var viewModel: TotalCVViewModel!
     let headerFont: UIFont = .systemFont(ofSize: 30, weight: .bold)
-    private var isEditingMode: Bool = false
+    var isEditingMode: Bool = false
     let navigationBarHeight = 91
     let editModeInset = 15
     let commonOffset = 15
     let addButtonSize = 120
     
-//MARK: - UI Component
+    //MARK: - UI Component
     private var fullScrollView: UIScrollView = .init().then {
         $0.backgroundColor = .systemBackground
         $0.showsVerticalScrollIndicator = true
@@ -109,7 +109,17 @@ class TotalCVViewController: UIViewController {
     
     private lazy var editModeButton: UIBarButtonItem = .init().then {
         $0.primaryAction = UIAction(image: UIImage(systemName: "wrench.and.screwdriver.fill"), handler: { _ in
+            
             self.isEditingMode.toggle()
+            
+            for section in 0..<self.categoryTableView.numberOfSections {
+                guard let headerView = self.categoryTableView.headerView(forSection: section) as? CategoryHeaderView else {
+                    continue
+                }
+                headerView.isEditingMode = self.isEditingMode
+            }
+            self.categoryTableView.reloadData() // 변경된 데이터를 다시 로드
+
             self.changeButton()
             self.changeMode()
         })
@@ -187,6 +197,11 @@ class TotalCVViewController: UIViewController {
         super.viewDidLayoutSubviews()
         profileImageView.circular()
     }
+    
+    override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
+        view.endEditing(true)
+    }
+    
     // MARK: - Navigation
     
     func configureNavigationBar() {
@@ -299,7 +314,7 @@ private extension TotalCVViewController {
         
         self.justCVView.addSubview(educationHeaderLabel)
         educationHeaderLabel.snp.makeConstraints { make in
-            make.leading.trailing.equalToSuperview().inset(20)
+            make.leading.trailing.equalToSuperview().inset(30)
             make.top.equalTo(totalUserInfoItemStackView.snp.bottom).offset(30)
         }
         
@@ -489,7 +504,7 @@ extension TotalCVViewController: UITableViewDelegate, UITableViewDataSource {
         
         if tableView == categoryTableView {
             let categoryView = tableView.dequeueReusableHeaderFooterView(withIdentifier: CategoryHeaderView.reuseIdentifier) as? CategoryHeaderView
-            categoryView?.titleLabel.text = viewModel.resumeCategory[section].title
+            categoryView?.titleTextField.text = viewModel.resumeCategory[section].title
             categoryView?.backgroundColor = .clear
             return categoryView
         } else {


### PR DESCRIPTION
## 변경점 설명
<!-- 필요 시 작성 -->
- 추가버튼(추후에 CategoryEditingViewController가 뜨게끔 구현)
- 섹션 편집 기능(UILabel을 TextField로 바꿔 EditMode일 때만 편집이 가능하게끔 구현)
- 키보드의 엔터 부분을 return으로 변경 후 눌렀을 때 키보드가 내려가게 끔 구현
## 참고 자료
<!-- 필요 시 작성 -->
<!-- 이미지, 링크, 플로우차트 등등 -->
<img src="https://user-images.githubusercontent.com/70786167/225847370-4ba8cd5e-816f-4ca0-84da-75008971c46e.png" width = "300">
<img src="https://user-images.githubusercontent.com/70786167/225847445-6457f200-850f-4c1b-8034-934df4b6f22e.png" width = "300">

## PR Checklist
<!-- 만족하는 항목은 [ ] 안에 "x" 를 입력해주세요. (ex: [x]) -->
<!-- 꼭!!! 체크하기 전에 다시 한번 확인해주세요!! -->

- [x] 변경 사항을 적용하고 빌드&테스트 실행을 해봤나요?
<!-- - [ ] [Code Convention](https://il-gob.notion.site/Code-Convention-29ce0d4e48e440b9bc74b1a19c99b57b)을 준수했나요? -->
