### PR TITLE
:sparkles: 로그인 상태 유지 기능 구현 (카카오 로그인만)

### DIFF
--- a/ItsME.xcodeproj/project.pbxproj
+++ b/ItsME.xcodeproj/project.pbxproj
@@ -89,6 +89,8 @@
 		DAD1D03429C068A600B12BF8 /* UIDRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAD1D03329C068A600B12BF8 /* UIDRepository.swift */; };
 		DAD1D03629C0826100B12BF8 /* UIDRepositoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAD1D03529C0826100B12BF8 /* UIDRepositoryTests.swift */; };
 		DAD1D03829C0B40100B12BF8 /* OSStatus+ToReadableString.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAD1D03729C0B40100B12BF8 /* OSStatus+ToReadableString.swift */; };
+		DAD1D05A29C1CEC500B12BF8 /* AppLoginStatusManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAD1D05929C1CEC500B12BF8 /* AppLoginStatusManager.swift */; };
+		DAD1D05C29C2DD9500B12BF8 /* AppLoginStatusManager+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAD1D05B29C2DD9500B12BF8 /* AppLoginStatusManager+Rx.swift */; };
 		DADDEEA629A8AD9A00D31B02 /* InsetTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = DADDEEA529A8AD9A00D31B02 /* InsetTextField.swift */; };
 		DAE6090B2942095400481742 /* TotalUserInfoItemStackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAE6090A2942095400481742 /* TotalUserInfoItemStackView.swift */; };
 		DAE6090D29420D9900481742 /* ItemAddButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAE6090C29420D9900481742 /* ItemAddButton.swift */; };
@@ -209,6 +211,8 @@
 		DAD1D03329C068A600B12BF8 /* UIDRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIDRepository.swift; sourceTree = "<group>"; };
 		DAD1D03529C0826100B12BF8 /* UIDRepositoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIDRepositoryTests.swift; sourceTree = "<group>"; };
 		DAD1D03729C0B40100B12BF8 /* OSStatus+ToReadableString.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OSStatus+ToReadableString.swift"; sourceTree = "<group>"; };
+		DAD1D05929C1CEC500B12BF8 /* AppLoginStatusManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppLoginStatusManager.swift; sourceTree = "<group>"; };
+		DAD1D05B29C2DD9500B12BF8 /* AppLoginStatusManager+Rx.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppLoginStatusManager+Rx.swift"; sourceTree = "<group>"; };
 		DADDEEA529A8AD9A00D31B02 /* InsetTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InsetTextField.swift; sourceTree = "<group>"; };
 		DAE6090A2942095400481742 /* TotalUserInfoItemStackView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TotalUserInfoItemStackView.swift; sourceTree = "<group>"; };
 		DAE6090C29420D9900481742 /* ItemAddButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItemAddButton.swift; sourceTree = "<group>"; };
@@ -517,6 +521,7 @@
 				DA53B73729B5BDA1000BBB26 /* Int+.swift */,
 				DAD1D02F29B759CE00B12BF8 /* Calendar+Current.swift */,
 				DAD1D03729C0B40100B12BF8 /* OSStatus+ToReadableString.swift */,
+				DAD1D05B29C2DD9500B12BF8 /* AppLoginStatusManager+Rx.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -578,6 +583,7 @@
 			children = (
 				D09AC9742918DE8B0081C0EC /* AppDelegate.swift */,
 				D09AC9762918DE8B0081C0EC /* SceneDelegate.swift */,
+				DAD1D05929C1CEC500B12BF8 /* AppLoginStatusManager.swift */,
 			);
 			path = Application;
 			sourceTree = "<group>";
@@ -943,6 +949,7 @@
 				DAAFB2532918EE5A007A8DF0 /* UserInfo.swift in Sources */,
 				DAFCFB6C294C3666006B287A /* EducationCell.swift in Sources */,
 				DA7201EC29309B9600A69519 /* AuthenticationServices+Rx.swift in Sources */,
+				DAD1D05C29C2DD9500B12BF8 /* AppLoginStatusManager+Rx.swift in Sources */,
 				D09AC9792918DE8B0081C0EC /* HomeViewController.swift in Sources */,
 				DA7201F02931EEE600A69519 /* CVInfo.swift in Sources */,
 				DADDEEA629A8AD9A00D31B02 /* InsetTextField.swift in Sources */,
@@ -1010,6 +1017,7 @@
 				D0CCF504292CCB4C00AD4AE6 /* CVCard.swift in Sources */,
 				DA01880D296D1477002C5CB0 /* PhoneNumberEditingViewController.swift in Sources */,
 				D0B1BA862988DA75003ACD41 /* CategoryCell.swift in Sources */,
+				DAD1D05A29C1CEC500B12BF8 /* AppLoginStatusManager.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ItsME/Application/AppLoginStatusManager.swift
+++ b/ItsME/Application/AppLoginStatusManager.swift
@@ -1,0 +1,65 @@
+//
+//  AppLoginStatusManager.swift
+//  ItsME
+//
+//  Created by Jaewon Yun on 2023/03/15.
+//
+
+import Foundation
+
+final class AppLoginStatusManager {
+    
+    /// 앱 사용자의 로그인 상태를 관리하는 싱글톤 객체입니다.
+    static let shared: AppLoginStatusManager = .init()
+    
+    private init() {}
+    
+    private let uidRepository: UIDRepository = .shared
+    
+    /// 앱의 사용자가 현재 로그인 되어있는지 여부를 반환합니다.
+    var isLoggedIn: Bool {
+        var result: Bool = false
+        let semaphore: DispatchSemaphore = .init(value: 0)
+        uidRepository.getUID { status, uid in
+            if status == errSecSuccess, let uid = uid {
+                result = true
+                #if DEBUG
+                    debugPrint("현재 로그인 되어있습니다. UID - \(uid)")
+                #endif
+            }
+            semaphore.signal()
+        }
+        semaphore.wait()
+        return result
+    }
+    
+    /// 앱 사용자를 로그인 처리 합니다.
+    func login(with uid: UIDRepository.UID) throws {
+        var isSuccessLogin: Bool = false
+        let semaphore: DispatchSemaphore = .init(value: 0)
+        uidRepository.saveUID(uid) { status in
+            if status == errSecSuccess {
+                isSuccessLogin = true
+            }
+            semaphore.signal()
+        }
+        semaphore.wait()
+        if !isSuccessLogin {
+            throw AppLoginError.loginFail
+        }
+    }
+    
+    /// 앱 사용자를 로그아웃 처리 합니다.
+    func logout() {
+        uidRepository.removeUID()
+    }
+}
+
+// MARK: - AppLoginError
+
+extension AppLoginStatusManager {
+    
+    enum AppLoginError: Error {
+        case loginFail
+    }
+}

--- a/ItsME/Application/SceneDelegate.swift
+++ b/ItsME/Application/SceneDelegate.swift
@@ -18,9 +18,13 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         guard let windowScene = (scene as? UIWindowScene) else { return }
         
         window = UIWindow(windowScene: windowScene)
-        let navigationController: UINavigationController = .init(rootViewController: LoginViewController())
-        window?.rootViewController = navigationController
         window?.makeKeyAndVisible()
+        
+        let isLoggedIn = false // TODO: 로그인 체크 로직 구현
+        
+        let rootViewController = isLoggedIn ? HomeViewController() : LoginViewController()
+        let navigationController: UINavigationController = .init(rootViewController: rootViewController)
+        window?.rootViewController = navigationController
     }
 
     func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {

--- a/ItsME/Application/SceneDelegate.swift
+++ b/ItsME/Application/SceneDelegate.swift
@@ -20,7 +20,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         window = UIWindow(windowScene: windowScene)
         window?.makeKeyAndVisible()
         
-        let isLoggedIn = false // TODO: 로그인 체크 로직 구현
+        let isLoggedIn = AppLoginStatusManager.shared.isLoggedIn
         
         let rootViewController = isLoggedIn ? HomeViewController() : LoginViewController()
         let navigationController: UINavigationController = .init(rootViewController: rootViewController)

--- a/ItsME/Presentation/Scenes/Login/LoginViewModel.swift
+++ b/ItsME/Presentation/Scenes/Login/LoginViewModel.swift
@@ -58,22 +58,20 @@ private extension LoginViewModel {
     func loginWithKakao() -> Observable<Void> {
         if (UserApi.isKakaoTalkLoginAvailable()) {
             return UserApi.shared.rx.loginWithKakaoTalk()
-                .map { AuthToken -> Void in
-                    #if DEBUG
-                        print("Login Success")
-                        print(AuthToken.accessToken)
-                    #endif
-                    return ()
+                .flatMap { authToken in
+                    return UserApi.shared.rx.me()
+                        .compactMap { $0.id }
+                        .map { String($0) }
                 }
+                .flatMap { AppLoginStatusManager.shared.rx.login(with: $0) }
         } else {
             return UserApi.shared.rx.loginWithKakaoAccount()
-                .map { AuthToken -> Void in
-                    #if DEBUG
-                        print("Login Success")
-                        print(AuthToken.accessToken)
-                    #endif
-                    return ()
+                .flatMap { authToken in
+                    return UserApi.shared.rx.me()
+                        .compactMap { $0.id }
+                        .map { String($0) }
                 }
+                .flatMap { AppLoginStatusManager.shared.rx.login(with: $0) }
         }
     }
 }

--- a/ItsME/Repositories/UIDRepository.swift
+++ b/ItsME/Repositories/UIDRepository.swift
@@ -41,7 +41,7 @@ extension UIDRepository {
     ///
     /// 이미 키체인에 `UID` 가 존재하는 경우 기존 값을 업데이트한 뒤 `completion` 이 호출됩니다.
     ///
-    /// 이 함수는 메인쓰레드에서 실행되지 않습니다.
+    /// - Note: 키체인에 `UID` 를 저장하는 작업과 `completion` 호출은 메인쓰레드에서 실행되지 않습니다.
     ///
     /// - Parameter uid: 키체인에 저장할 UID
     /// - Parameter completion: 성공적으로 키체인에 저장되면 매개변수로 `errSecSuccess` 값이 전달됩니다. 저장에 실패할 경우 실패 원인에 대한 `OSStatus` 값이 전달됩니다.
@@ -66,7 +66,7 @@ extension UIDRepository {
     
     /// 키체인에 존재하는 `UID` 를 삭제한 뒤 `completion` 이 호출됩니다.
     ///
-    /// 이 함수는 메인쓰레드에서 실행되지 않습니다.
+    /// - Note: `UID` 를 삭제하는 작업과 `completion` 호출은 메인쓰레드에서 실행되지 않습니다.
     ///
     /// - Parameter completion: 성공적으로 키체인에서 UID 가 삭제되면 매개변수로 `errSecSuccess` 값이 전달됩니다. 삭제에 실패할 경우 실패 원인에 대한 `OSStatus` 값이 전달됩니다.
     func removeUID(_ completion: ((OSStatus) -> Void)? = nil) {
@@ -83,7 +83,7 @@ extension UIDRepository {
     ///
     /// 키체인에 `UID` 가 존재하지 않을 경우 `UID` 매개변수에 nil 이 담긴 `completion` 이 호출됩니다.
     ///
-    /// 이 함수는 메인쓰레드에서 실행되지 않습니다.
+    /// - Note: 키체인을 검색하는 작업과 `completion` 호출은 메인쓰레드에서 실행되지 않습니다.
     func getUID(_ completion: @escaping ((OSStatus, UID?) -> Void)) {
         let query: [CFString: Any] = [kSecClass: kSecClassGenericPassword,
                                 kSecAttrService: service as Any,
@@ -105,7 +105,7 @@ extension UIDRepository {
     
     /// 주어진 `UIDData` 로 키체인 저장된 `UID` 를 업데이트한 뒤 `completion` 이 호출됩니다.
     ///
-    /// 이 함수는 메인쓰레드에서 실행되지 않습니다.
+    /// - Note: 키체인에 `UIDData` 를 업데이트하는 작업과 `completion` 호출은 메인쓰레드에서 실행되지 않습니다.
     ///
     /// - Parameter uidData: 키체인에 업데이트할 `UID Data`
     /// - Parameter completion: 성공적으로 키체인에 `UID Data` 가 업데이트될 경우 매개변수로 `errSecSuccess` 값이 전달됩니다. 업데이트에 실패할 경우 실패 원인에 대한 `OSStatus` 값이 전달됩니다.
@@ -124,7 +124,7 @@ extension UIDRepository {
     ///
     /// 이 함수는 내부적으로 `updateUIDData(_:_:)` 를 호출합니다.
     ///
-    /// 이 함수는 메인쓰레드에서 실행되지 않습니다.
+    /// - Note: 키체인에 `UID` 를 업데이트하는 작업과 `completion` 호출은 메인쓰레드에서 실행되지 않습니다.
     ///
     /// - Parameter uid: 키체인에 업데이트할 `UID`
     /// - Parameter completion: 성공적으로 키체인에 `UID` 가 업데이트될 경우 매개변수로 `errSecSuccess` 값이 전달됩니다. 업데이트에 실패할 경우 실패 원인에 대한 `OSStatus` 값이 전달됩니다.

--- a/ItsME/Utils/Extensions/AppLoginStatusManager+Rx.swift
+++ b/ItsME/Utils/Extensions/AppLoginStatusManager+Rx.swift
@@ -1,0 +1,27 @@
+//
+//  AppLoginStatusManager+Rx.swift
+//  ItsME
+//
+//  Created by Jaewon Yun on 2023/03/16.
+//
+
+import RxSwift
+
+extension Reactive where Base: AppLoginStatusManager {
+    
+    func login(with uid: UIDRepository.UID) -> Single<Void> {
+        return Single
+            .create { observer in
+                do {
+                    try AppLoginStatusManager.shared.login(with: uid)
+                    observer(.success(()))
+                } catch {
+                    observer(.failure(AppLoginStatusManager.AppLoginError.loginFail))
+                }
+                return Disposables.create()
+            }
+            .observe(on: MainScheduler.instance)
+    }
+}
+
+extension AppLoginStatusManager: ReactiveCompatible {}

--- a/ItsMETests/UIDRepositoryTests.swift
+++ b/ItsMETests/UIDRepositoryTests.swift
@@ -12,6 +12,14 @@ final class UIDRepositoryTests: XCTestCase {
     
     let sut: UIDRepository! = .shared
     
+    override func setUp() {
+        let expectation = expectation(description: "setUpRemoveUID")
+        sut.removeUID { _ in
+            expectation.fulfill()
+        }
+        waitForExpectations(timeout: 2)
+    }
+    
     override func tearDown() {
         sut.removeUID()
     }


### PR DESCRIPTION
## 변경점 설명
<!-- 필요 시 작성 -->
#### 메인 변경점
- 앱 전역에서 로그인을 관리하는 클래스 추가
- 저장된 로그인 상태에 따라 rootViewController 결정
- [카카오 로그인시 키체인에 UID 를 저장하여 로그인 상태 유지 구현](https://github.com/ILGOB/It-sME/commit/bac750ea3c530ed6ad540c4a5549e4eee4962dca)
  - 현재 로그아웃 기능이 없어서 AppLoginStatusManager 객체에 직접 접근하여 수동으로 logout() 호출해 줘야함
  - 별도의 KeychainWrapper 를 개발중이라 추후 로그인 관련 구현부 바뀔 수 있음

#### 그 외
- [깨끗한 테스트 환경을 위해 setUp 메소드에서 removeUID() 호출](https://github.com/ILGOB/It-sME/commit/bc71ae600334725a6067d1833bff701099075ac3)
- [UIDRepository 의 API 함수에 대한 주석 정확하게 수정](https://github.com/ILGOB/It-sME/commit/ba0b0de8efd7dd673b7729d48561ce1163ee8f45)


## 참고 자료
<!-- 필요 시 작성 -->
<!-- 이미지, 링크, 플로우차트 등등 -->
https://user-images.githubusercontent.com/81426024/225943469-19c2e9aa-13d1-416b-a239-7636ea4cd620.mp4
  
> 어 왜 마지막에 조금 짤렸지...

## PR Checklist
<!-- 만족하는 항목은 [ ] 안에 "x" 를 입력해주세요. (ex: [x]) -->
<!-- 꼭!!! 체크하기 전에 다시 한번 확인해주세요!! -->

- [x] 변경 사항을 적용하고 빌드&테스트 실행을 해봤나요?
<!-- - [ ] [Code Convention](https://il-gob.notion.site/Code-Convention-29ce0d4e48e440b9bc74b1a19c99b57b)을 준수했나요? -->
