### PR TITLE
:adhesive_bandage: 앱 크래시 버그 긴급 수정

### DIFF
--- a/ItsME/Presentation/Scenes/Home/HomeViewController.swift
+++ b/ItsME/Presentation/Scenes/Home/HomeViewController.swift
@@ -355,9 +355,8 @@ private extension HomeViewController {
                         cancelAction: .init(title: "아니오", style: .cancel),
                         okAction: .init(title: "삭제", style: .destructive, handler: { _ in
                             self.viewModel.removeCV(cvInfo: cvInfo)
-                                .subscribe(onNext: { _ in
-//FIXME: - 추후에 HomeViewModel의 [cvsInfo]에 이벤트를 추가하는 방향으로 개선
-                                    self.bindViewModel()
+                                .emit(with: self, onNext: { owner, _ in
+                                    owner.bindViewModel() //FIXME: 추후에 HomeViewModel의 [cvsInfo]에 이벤트를 추가하는 방향으로 개선
                                 })
                                 .disposed(by: self.disposeBag)
                         })

--- a/ItsME/Presentation/Scenes/Home/HomeViewModel.swift
+++ b/ItsME/Presentation/Scenes/Home/HomeViewModel.swift
@@ -25,8 +25,8 @@ final class HomeViewModel: ViewModelType {
     
     private(set) var userInfo: UserInfo = .empty
     
-    func removeCV(cvInfo: CVInfo) -> Observable<Void> {
-        return self.cvRepository.removeCV(by: cvInfo.uuid).asObservable()
+    func removeCV(cvInfo: CVInfo) -> Signal<Void> {
+        return self.cvRepository.removeCV(by: cvInfo.uuid).asSignalOnErrorJustComplete()
     }
         
     func transform(input: Input) -> Output {


### PR DESCRIPTION

## 변경점 설명
<!-- 필요 시 작성 -->
- 일반 subscribe() 는 기본적으로 메인스레드가 아닌곳에서 실행됨. 그런데 해당 subscribe의 onNext 블럭 안에서 bindViewModel() 을 호출하여 Driver 관련 코드가 메인스레드가 아닌곳에서 실행되게 되어 RxSwift 내에서 fatalError 가 실행됨
  - `Observable` -> `Signal` 로 변환하여 해결


<!-- ## PR Checklist -->
<!-- 만족하는 항목은 [ ] 안에 "x" 를 입력해주세요. (ex: [x]) -->
<!-- 꼭!!! 체크하기 전에 다시 한번 확인해주세요!! -->

<!-- - [ ] 변경 사항을 적용하고 빌드&테스트 실행을 해봤나요? -->
<!-- - [ ] [Code Convention](https://il-gob.notion.site/Code-Convention-29ce0d4e48e440b9bc74b1a19c99b57b)을 준수했나요? -->
