### PR TITLE
[Me-81] 프로필 사진 변경 후 다른 항목 수정 시 프로필 사진 다시 돌아오는 문제 해결

### DIFF
--- a/ItsME/Presentation/Scenes/Home/HomeViewController.swift
+++ b/ItsME/Presentation/Scenes/Home/HomeViewController.swift
@@ -35,7 +35,7 @@ final class HomeViewController: UIViewController {
     private lazy var profileEditingButton: UIButton = {
         let action = UIAction { _ in
             let profileEditingViewModel: ProfileEditingViewModel = .init(
-                initalProfileImage: self.profileImageView.image?.jpegData(compressionQuality: 1.0),
+                initalProfileImageData: self.profileImageView.image?.jpegData(compressionQuality: 1.0),
                 userInfo: self.viewModel.userInfo
             )
             let profileEditingViewController: ProfileEditingViewController = .init(viewModel: profileEditingViewModel)

--- a/ItsME/Presentation/Scenes/ProfileEditing/ProfileEditingViewController.swift
+++ b/ItsME/Presentation/Scenes/ProfileEditing/ProfileEditingViewController.swift
@@ -178,7 +178,7 @@ private extension ProfileEditingViewController {
                     okAction: UIAlertAction(title: "예", style: .default)
                 ).asSignal()
             },
-            newProfileImageData: imagePickerController.rx.didFinishPickingImage
+            newProfileImageData: imagePickerController.rx.didFinishPickingImage(animated: true)
                 .map { $0?.jpegData(compressionQuality: 0.7) }
                 .asDriverOnErrorJustComplete()
         )

--- a/ItsME/Presentation/Scenes/ProfileEditing/ProfileEditingViewController.swift
+++ b/ItsME/Presentation/Scenes/ProfileEditing/ProfileEditingViewController.swift
@@ -446,7 +446,10 @@ struct ProfileEditingViewControllerRepresenter: UIViewControllerRepresentable {
     
     func makeUIViewController(context: Context) -> UIViewController {
         let navigationController: UINavigationController = .init(rootViewController: .init())
-        let profileEditingViewModel: ProfileEditingViewModel = .init(initalProfileImage: Data(), userInfo: .empty)
+        let profileEditingViewModel: ProfileEditingViewModel = .init(
+            initalProfileImageData: UIImage.defaultProfileImage.jpegData(compressionQuality: 1.0),
+            userInfo: .empty
+        )
         let profileEditingViewController: ProfileEditingViewController = .init(viewModel: profileEditingViewModel)
         navigationController.pushViewController(profileEditingViewController, animated: false)
         return navigationController

--- a/ItsME/Presentation/Scenes/ProfileEditing/ProfileEditingViewModel.swift
+++ b/ItsME/Presentation/Scenes/ProfileEditing/ProfileEditingViewModel.swift
@@ -13,27 +13,9 @@ import Then
 
 final class ProfileEditingViewModel: ViewModelType {
     
-    struct Input {
-        let tapEditingCompleteButton: Signal<Void>
-        let userName: Driver<String>
-        let viewDidLoad: Driver<Void>
-        let logoutTrigger: Signal<Void>
-        let newProfileImageData: Driver<Data?>
-    }
-    
-    struct Output {
-        let profileImageData: Driver<Data?>
-        let userName: Driver<String>
-        let userInfoItems: Driver<[UserInfoItem]>
-        let educationItems: Driver<[EducationItem]>
-        let tappedEditingCompleteButton: Signal<Void>
-        let viewDidLoad: Driver<Void>
-        let logoutComplete: Signal<Void>
-    }
-    
     private let userRepository: UserRepository = .shared
     
-    private let initalProfileImage: Data
+    private let initalProfileImageData: Data?
     private let userInfoRelay: BehaviorRelay<UserInfo>
     
     var currentBirthday: Date {
@@ -62,8 +44,8 @@ final class ProfileEditingViewModel: ViewModelType {
         userInfoRelay.value.educationItems
     }
     
-    init(initalProfileImage: Data?, userInfo: UserInfo) {
-        self.initalProfileImage = initalProfileImage ?? .init()
+    init(initalProfileImageData: Data?, userInfo: UserInfo) {
+        self.initalProfileImageData = initalProfileImageData
         self.userInfoRelay = .init(value: userInfo)
     }
     
@@ -85,9 +67,12 @@ final class ProfileEditingViewModel: ViewModelType {
                 Storage.storage().reference().child($0.profileImageURL).rx.getData().map { $0 }
                     .asDriverOnErrorJustComplete()
             }
+                .asObservable()
+                .take(1)
+                .asDriverOnErrorJustComplete()
         )
-            .startWith(initalProfileImage)
-            
+            .startWith(initalProfileImageData)
+        
         let userName = Driver.merge(input.userName,
                                     userInfoDriver.map { $0.name })
             .startWith(userInfoRelay.value.name)
@@ -127,6 +112,29 @@ final class ProfileEditingViewModel: ViewModelType {
             viewDidLoad: viewDidLoad,
             logoutComplete: logoutComplete
         )
+    }
+}
+
+// MARK: - Input & Output
+
+extension ProfileEditingViewModel {
+    
+    struct Input {
+        let tapEditingCompleteButton: Signal<Void>
+        let userName: Driver<String>
+        let viewDidLoad: Driver<Void>
+        let logoutTrigger: Signal<Void>
+        let newProfileImageData: Driver<Data?>
+    }
+    
+    struct Output {
+        let profileImageData: Driver<Data?>
+        let userName: Driver<String>
+        let userInfoItems: Driver<[UserInfoItem]>
+        let educationItems: Driver<[EducationItem]>
+        let tappedEditingCompleteButton: Signal<Void>
+        let viewDidLoad: Driver<Void>
+        let logoutComplete: Signal<Void>
     }
 }
 

--- a/ItsME/Utils/Reactive/BaseExtensions/UIImagePickerController+Rx.swift
+++ b/ItsME/Utils/Reactive/BaseExtensions/UIImagePickerController+Rx.swift
@@ -14,16 +14,16 @@ extension Reactive where Base: UIImagePickerController {
         return UIImagePickerControllerDelegateProxy.proxy(for: self.base)
     }
     
-    var didFinishPickingImage: Observable<UIImage?> {
+    func didFinishPickingImage(animated: Bool) -> Observable<UIImage?> {
         let selector = #selector(UIImagePickerControllerDelegate.imagePickerController(_:didFinishPickingMediaWithInfo:))
         return delegateProxy
             .methodInvoked(selector)
             .map { parameters in
-                self.base.dismiss(animated: true)
+                self.base.dismiss(animated: animated)
                 
                 guard let info = parameters[1] as? [UIImagePickerController.InfoKey: Any] else {
-                    assertionFailure("delegate 함수의 파라미터 타입이 일치하지 않습니다.")
-                    return nil
+                    throw RxCocoaError.castingError(object: parameters[1],
+                                                    targetType: [UIImagePickerController.InfoKey: Any].self)
                 }
                 if let image = info[.editedImage] as? UIImage {
                     return image


### PR DESCRIPTION
## 변경점 설명
<!-- 필요 시 작성 -->
프로필 수정 화면에서 다른 항목 편집 시 계속 프로필 사진이 초기화되는 문제 해결

