### PR TITLE
:bug: (ME-100) 확인 Alert 가 나오는 삭제 버튼을 두 번 이상 터치 시 Alert 가 나오지 않는 문제 해결

### DIFF
--- a/ItsME/Utils/Extensions/UIViewController+presentConfirmAlert.swift
+++ b/ItsME/Utils/Extensions/UIViewController+presentConfirmAlert.swift
@@ -50,12 +50,20 @@ extension Reactive where Base: UIViewController {
         animated: Bool = true
     ) -> ControlEvent<Void> {
         let source: Observable<Void> = .create { observer in
+            MainScheduler.ensureRunningOnMainThread()
+            
             let okActionProxy: UIAlertAction = .init(title: okAction.title, style: okAction.style) { _ in
                 observer.onNext(())
                 observer.onCompleted()
             }
-            self.base.presentConfirmAlert(title: title, message: message, cancelAction: cancelAction, okAction: okActionProxy, animated: animated)
-            
+            let cancelActionProxy: UIAlertAction = .init(title: cancelAction.title, style: cancelAction.style) { _ in
+                observer.onCompleted()
+            }
+            self.base.presentConfirmAlert(title: title,
+                                          message: message,
+                                          cancelAction: cancelActionProxy,
+                                          okAction: okActionProxy,
+                                          animated: animated)
             return Disposables.create()
         }
         


### PR DESCRIPTION
## 원인
flatMap operator 내부에서 생성한 Sequence 를 정상적으로 종료(onComplete)시키지 않아서 발생한 문제

## 해결 방안
취소 버튼을 눌렀을 때 `onComplete` 호출