### PR TITLE
[Me-122] 버그 해결

### DIFF
--- a/ItsME/Entities/Resume.swift
+++ b/ItsME/Entities/Resume.swift
@@ -8,6 +8,7 @@
 import Foundation
 
 final class Resume: Codable {
+    
     var category: [ResumeCategory]
     
     init(category: [ResumeCategory]) {
@@ -18,12 +19,16 @@ final class Resume: Codable {
 // MARK: - CodingKeys
 
 extension Resume {
+    
     enum CodingKeys: CodingKey {
-    case category
+        case category
     }
 }
 
+// MARK: - Empty
+
 extension Resume {
+    
     static var empty: Resume {
         .init(category: [])
     }

--- a/ItsME/Entities/ResumeCategory.swift
+++ b/ItsME/Entities/ResumeCategory.swift
@@ -16,6 +16,17 @@ final class ResumeCategory: Codable {
         self.title = title
         self.items = items
     }
+    
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        
+        self.title = try container.decode(String.self, forKey: .title)
+        do {
+            self.items = try container.decode([ResumeItem].self, forKey: .items)
+        } catch {
+            self.items = []
+        }
+    }
 }
 
 // MARK: - CodingKeys

--- a/ItsME/Entities/ResumeCategory.swift
+++ b/ItsME/Entities/ResumeCategory.swift
@@ -8,6 +8,7 @@
 import Foundation
 
 final class ResumeCategory: Codable {
+    
     var title: String
     var items: [ResumeItem]
     
@@ -20,13 +21,17 @@ final class ResumeCategory: Codable {
 // MARK: - CodingKeys
 
 extension ResumeCategory {
+    
     enum CodingKeys: CodingKey {
-    case title
-    case items
+        case title
+        case items
     }
 }
 
+// MARK: - Empty
+
 extension ResumeCategory {
+    
     static var empty: ResumeCategory {
         .init(
             title: "",

--- a/ItsME/Entities/ResumeItem.swift
+++ b/ItsME/Entities/ResumeItem.swift
@@ -8,6 +8,7 @@
 import Foundation
 
 final class ResumeItem: Codable {
+    
     var period: String
     var title: String
     var secondTitle: String
@@ -47,20 +48,23 @@ final class ResumeItem: Codable {
 // MARK: - CodingKeys
 
 extension ResumeItem {
+    
     enum CodingKeys: CodingKey {
-    case period
-    case title
-    case secondTitle
-    case description
+        case period
+        case title
+        case secondTitle
+        case description
     }
 }
 
+// MARK: - Empty
+
 extension ResumeItem {
+    
     static var empty: ResumeItem {
-        .init(
-            period: "",
-            title: "",
-            secondTitle: "",
-            description: "")
+        .init(period: "",
+              title: "",
+              secondTitle: "",
+              description: "")
     }
 }

--- a/ItsME/Presentation/Scenes/TotalCV/TotalCVViewModel.swift
+++ b/ItsME/Presentation/Scenes/TotalCV/TotalCVViewModel.swift
@@ -45,7 +45,7 @@ final class TotalCVViewModel: ViewModelType {
             Storage.storage().reference().child($0.profileImageURL).rx.getData().map { $0 }
                 .asDriverOnErrorJustComplete()
         }
-                
+        
         let tappedEditingCompleteButton = input.doneTrigger
             .withLatestFrom(cvInfoDriver)
             .flatMapFirst { cvInfo in
@@ -63,15 +63,18 @@ final class TotalCVViewModel: ViewModelType {
     }
 }
 
-// MARK: - International Function
+// MARK: - Methods
+
 extension TotalCVViewModel {
+    
     func removeResumeCategory(indexPath: IndexPath, resumeCatgory: ResumeCategory) {
         let changedCVInfo = cvInfoRelay.value
         changedCVInfo.resume.category.remove(at: indexPath.section)
     }
 }
 
-//MARK: - Input & Output
+// MARK: - Input & Output
+
 extension TotalCVViewModel {
     
     struct Input {
@@ -88,21 +91,26 @@ extension TotalCVViewModel {
     }
 }
 
-// MARK: - Extension Delegate
-extension TotalCVViewModel:
-    CoverLetterEditingViewModelDelegate, CategoryEditingViewModelDelegate, ResumeItemEditingViewModelDelegate {
+// MARK: - CoverLetterEditingViewModelDelegate
+
+extension TotalCVViewModel: CoverLetterEditingViewModelDelegate {
     
-    func resumeItemEditingViewModelDidEndEditing(with resumeItem: ResumeItem, at indexPath: IndexPath) {
+    func coverLetterEditingViewModelDidEndEditing(with coverLetterItem: CoverLetterItem, at indexPath: IndexPath) {
         let changedCVInfo = cvInfoRelay.value
-        changedCVInfo.resume.category[indexPath.section].items[indexPath.row] = resumeItem
+        changedCVInfo.coverLetter.items[indexPath.row] = coverLetterItem
         cvInfoRelay.accept(changedCVInfo)
     }
     
-    func resumeItemEditingViewModelDidAppend(with resumeItem: ResumeItem, at section: Int) {
+    func coverLetterEditingViewModelDidAppend(coverLetterItem: CoverLetterItem) {
         let changedCVInfo = cvInfoRelay.value
-        changedCVInfo.resume.category[section].items.append(resumeItem)
+        changedCVInfo.coverLetter.items.append(coverLetterItem)
         cvInfoRelay.accept(changedCVInfo)
     }
+}
+
+// MARK: - CategoryEditingViewModelDelegate
+
+extension TotalCVViewModel: CategoryEditingViewModelDelegate {
     
     func categoryEditingViewModelDidEndEditing(with title: String, at section: Int) {
         let changedCVInfo = cvInfoRelay.value
@@ -121,16 +129,21 @@ extension TotalCVViewModel:
         changedCVInfo.resume.category.remove(at: section)
         cvInfoRelay.accept(changedCVInfo)
     }
+}
+
+// MARK: - ResumeItemEditingViewModelDelegate
+
+extension TotalCVViewModel: ResumeItemEditingViewModelDelegate {
     
-    func coverLetterEditingViewModelDidEndEditing(with coverLetterItem: CoverLetterItem, at indexPath: IndexPath) {
+    func resumeItemEditingViewModelDidEndEditing(with resumeItem: ResumeItem, at indexPath: IndexPath) {
         let changedCVInfo = cvInfoRelay.value
-        changedCVInfo.coverLetter.items[indexPath.row] = coverLetterItem
+        changedCVInfo.resume.category[indexPath.section].items[indexPath.row] = resumeItem
         cvInfoRelay.accept(changedCVInfo)
     }
     
-    func coverLetterEditingViewModelDidAppend(coverLetterItem: CoverLetterItem) {
+    func resumeItemEditingViewModelDidAppend(with resumeItem: ResumeItem, at section: Int) {
         let changedCVInfo = cvInfoRelay.value
-        changedCVInfo.coverLetter.items.append(coverLetterItem)
+        changedCVInfo.resume.category[section].items.append(resumeItem)
         cvInfoRelay.accept(changedCVInfo)
     }
 }


### PR DESCRIPTION
## 변경점 설명
<!-- 필요 시 작성 -->
- [이력서 카테고리 추가 기능쪽 버그](https://itsme-ilgob-com.atlassian.net/browse/ME-122) 해결
  - **원인**: `CVInfo` 의 하위 엔티티인 `ResumeCategory` 에 `decode initializer` 가 정의되어 있지 않아서 DB 상에 키가 하나 없을 때 decode 가 제대로 되지 않는 에러 발생
  - **해결**: `decode initializer` 정의하여 키가 존재하지 않을 시, 에러를 catch 하여 빈 배열로 초기화
